### PR TITLE
Files for Seeker and ProphET

### DIFF
--- a/conda_environments/prophet.yaml
+++ b/conda_environments/prophet.yaml
@@ -1,0 +1,17 @@
+name: prophet
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - blast-legacy
+  - emboss
+  - bedtools
+  - perl-bioperl
+  - perl-svg
+  - perl-gd
+  - perl-gd-svg
+  - perl-lwp-simple
+  - perl-xml-simple
+  - perl-mozilla-ca
+  - perl-lwp-protocol-https

--- a/conda_environments/seeker.yaml
+++ b/conda_environments/seeker.yaml
@@ -1,0 +1,5 @@
+name: seeker
+dependencies:
+  - pip
+  - pip:
+      - seeker

--- a/rules/prophET_rules.smk
+++ b/rules/prophET_rules.smk
@@ -1,0 +1,73 @@
+# config for all tests
+test_genomes = os.path.join(workflow.basedir, "../genbank")
+scripts = os.path.join(workflow.basedir, "../scripts")
+GENOMES, = glob_wildcards(os.path.join(test_genomes, '{genome}.gb.gz'))
+
+testDir = os.path.join(workflow.basedir, '../tests')
+outputdir = os.path.join(testDir, outDirName)
+if not os.path.exists(testDir):
+    os.mkdir(testDir)
+
+
+#INPUT PREPROCESS
+rule unpack_gbk:
+    input:
+        gbk_gz = os.path.join(test_genomes, "{genome}.gb.gz")
+    output:
+        tmp_gbk = temp(os.path.join(outputdir, "{genome}.prophET.tmp.gbk"))
+    shell:
+        """
+        gzip -dkc {input.gbk_gz} > {output.tmp_gbk}
+        """
+
+rule sanitize_accesions:  # if accessions include dots they must be replaced (_dot_) to avoid problem during prophET run
+    input:
+        tmp_gbk = os.path.join(outputdir, "{genome}.prophET.tmp.gbk")
+    output:
+        fixed_tmp_gbk = temp(os.path.join(outputdir, "{genome}.prophET.fixed.tmp.gbk"))
+    params:
+        env = os.path.join(workflow.basedir, '../')
+    conda:
+        "../conda_environments/roblib.yaml"
+    shell:
+        """
+        export PYTHONPATH={params.env};
+        python3 {scripts}/sanitize_genbank.py --in {input.tmp_gbk} --out {output.fixed_tmp_gbk}
+        """
+
+rule convert_gb_to_fna:
+    input:
+        tmp_gbk = os.path.join(outputdir, "{genome}.prophET.fixed.tmp.gbk")
+    output:
+        fna = os.path.join(outputdir, "{genome}.prophET.fna")
+    params:
+        env = os.path.join(workflow.basedir, '../'),
+        out = os.path.join(outputdir, "{genome}.prophET")
+    conda:
+        "../conda_environments/roblib.yaml"
+    shell:
+        """
+        echo {workflow.basedir}
+        export PYTHONPATH={params.env};
+        python3 {scripts}/genbank2sequences.py -g {input.tmp_gbk} -n {params.out}
+        """
+
+rule get_prophet_gff:
+    input:
+        tmp_gbk = os.path.join(outputdir, "{genome}.prophET.fixed.tmp.gbk")
+    output:
+        tmp_gff = temp(os.path.join(outputdir,"{genome}.prophET.tmp.gff")),
+        gff = os.path.join(outputdir, "{genome}.prophET.gff"),
+    params:
+        perl5lib = os.path.join(scripts,'GFFLib'),
+        standardisation_script = os.path.join(scripts,'GFFLib/gff_rewrite.pl'),
+        logfile = os.path.join(outputdir,"gbk2gff.conversion.log")
+    conda:
+        "../conda_environments/prophet.yaml"
+    shell:
+        """
+        export PERL5LIB={params.perl5lib}
+        echo {input.tmp_gbk} 2>> {params.logfile}
+        bp_genbank2gff3.pl {input.tmp_gbk} --outdir stdout > {output.tmp_gff} 2>> {params.logfile}
+        perl {params.standardisation_script} --input {output.tmp_gff} --output {output.gff} --add_missing_features 2>> {params.logfile}
+        """

--- a/scripts/GFFLib/GFFCDS.pm
+++ b/scripts/GFFLib/GFFCDS.pm
@@ -1,0 +1,284 @@
+package GFFCDS;
+use strict 'vars';
+use strict 'refs';
+
+require GFFTranscript;
+
+# use overload '==' => \&compare;
+
+sub new {
+	my ( $exon_name, $start_coord, $end_coord, $phase, $parent ) = @_;
+	my $self = {
+		id     => $exon_name,
+		start  => $start_coord,
+		end    => $end_coord,
+		phase  => $phase,
+		parent => $parent
+	};
+
+	bless $self, GFFCDS;
+
+	return $self;
+}
+
+sub copy {
+	my ( $ref, $parent ) = @_;
+
+	my $self;
+
+	if ( defined $parent ) {
+		$self = {
+			id     => $ref->{id},
+			start  => $ref->{start},
+			end    => $ref->{end},
+			phase  => $ref->{phase},
+			parent => $parent
+		};
+	}
+	else {
+		$self = {
+			id     => $ref->{id},
+			start  => $ref->{start},
+			end    => $ref->{end},
+			phase  => $ref->{phase},
+			parent => $ref->{parent}
+		};
+	}
+
+	bless $self, GFFCDS;
+
+	# Copying other atrributes
+	$self->cpy_attrib($ref);
+	return $self;
+}
+
+sub cpy_attrib {
+	my $self = shift;
+	my ($ref) = @_;
+
+	foreach my $ckey ( keys %{ $ref->{attrib} } ) {
+		$self->{attrib}{$ckey} = $ref->{attrib}{$ckey};
+	}
+}
+
+sub get_parent {
+	my $self = shift;
+	return $self->{parent};
+}
+
+sub set_id {
+	my $self = shift;
+
+	my ($new_id) = @_;
+
+	$self->{id} = $new_id;
+}
+
+sub get_id {
+	my $self = shift;
+	return $self->{id};
+}
+
+sub get_start {
+	my $self = shift;
+	return $self->{start};
+}
+
+sub get_end {
+	my $self = shift;
+	return $self->{end};
+}
+
+sub get_length {
+	my $self = shift;
+	return $self->{end} - $self->{start} + 1;
+}
+
+sub get_phase {
+	my $self = shift;
+	return $self->{phase};
+}
+
+sub set_phase {
+	my $self = shift;
+	my ($phase) = @_;
+	$self->{phase} = $phase;
+}
+
+sub set_start {
+	my $self = shift;
+	my ($coord_start) = @_;
+
+	$self->{start} = $coord_start;
+}
+
+sub set_end {
+	my $self = shift;
+	my ($coord_end) = @_;
+
+	$self->{end} = $coord_end;
+}
+
+sub set_parent_exon {
+	my $self = shift;
+	my ($ref_exon) = @_;
+
+	$self->{exon} = $ref_exon;
+}
+
+sub get_parent_exon {
+	my $self = shift;
+	return $self->{exon};
+}
+
+sub is_attached {
+	my $self = shift;
+	return defined $self->{exon};
+}
+
+sub toGFF {
+	my $self = shift;
+
+	my ( $chrom, $parent, $strand ) = @_;
+
+	my $str =
+	    $chrom . "\t.\t" . "CDS" . "\t"
+	  . $self->{start} . "\t"
+	  . $self->{end} . "\t.\t"
+	  . $strand . "\t"
+	  . $self->{phase} . "\t" . "ID="
+	  . $self->{id} . ";"
+	  . "Parent=$parent;\n";
+	return $str;
+}
+
+sub toGTF {
+	my $self = shift;
+
+	my ( $chrom, $parent, $strand ) = @_;
+
+	my $str;
+	
+	#print STDERR "INSIDE CDS\n";
+	#getc();
+
+	# If the CDS is the first one in the transcript 
+	if( $self->is_first_strand_based() ){
+		my $start_start_codon;
+		my $end_start_codon;
+		
+	#print STDERR "FIRST CDS\n";
+	#getc();
+		
+
+		if ( $strand eq '+' ) {
+			$start_start_codon = $self->{start};
+			$end_start_codon =  $self->{start} + 2;
+		}
+		else {
+			$start_start_codon = $self->{end} - 2;
+			$end_start_codon = $self->{end};
+		}
+		
+		$str .=
+		    $chrom . "\t.\t" . "start_codon" . "\t"
+		  . $start_start_codon . "\t"
+		  . $end_start_codon . "\t.\t"
+		  . $strand . "\t"
+		  . $self->{phase} . "\n";
+
+
+
+	# If the CDS is the last one in the transcript the STOP codon
+	# should not be part of it
+	}
+	
+	if ( $self->is_last_strand_based() ) {
+
+	#print STDERR "LAST CDS\n";
+	#getc();
+		
+
+		my $start = $self->{start};
+		my $end   = $self->{end};
+
+		if ( $strand eq '+' ) {
+			$end -= 3;
+		}
+		else {
+			$start += 3;
+		}
+
+		if( $start < $end ){
+		$str .=
+		    $chrom . "\t.\t" . "CDS" . "\t" 
+		  . $start . "\t" 
+		  . $end . "\t.\t"
+		  . $strand . "\t"
+		  . $self->{phase} . "\n";
+		}
+		  
+		  
+		my $start_stop_codon;
+		my $end_stop_codon;
+
+		if ( $strand eq '+' ) {
+			$start_stop_codon = $self->{end} - 2;
+			$end_stop_codon =  $self->{end};
+		}
+		else {
+			$start_stop_codon = $self->{start};
+			$end_stop_codon = $self->{start} + 2;
+		}
+		
+		$str .=
+		    $chrom . "\t.\t" . "stop_codon" . "\t"
+		  . $start_stop_codon . "\t"
+		  . $end_stop_codon . "\t.\t"
+		  . $strand . "\t"
+		  . $self->{phase} . "\n";
+		  
+
+	} else {
+		
+	#print STDERR "REGULAR CDS\n";
+	#getc();
+		
+		$str .=
+		    $chrom . "\t.\t" . "CDS" . "\t"
+		  . $self->{start} . "\t"
+		  . $self->{end} . "\t.\t"
+		  . $strand . "\t"
+		  . $self->{phase} . "\n";
+
+	}
+
+	return $str;
+}
+
+sub set_attribute {
+	my $self = shift;
+	my ( $key, $value ) = @_;
+
+	return $self->{attrib}{$key} = $value;
+}
+
+sub get_attribute {
+	my $self = shift;
+	my ($key) = @_;
+	return $self->{attrib}{$key};
+}
+
+sub is_last_strand_based {
+	my $self = shift;
+
+	return $self eq $self->{parent}->get_last_CDS_strand_based();
+}
+
+sub is_first_strand_based {
+	my $self = shift;
+
+	return $self eq $self->{parent}->get_first_CDS_strand_based();
+}
+
+return 1;

--- a/scripts/GFFLib/GFFExon.pm
+++ b/scripts/GFFLib/GFFExon.pm
@@ -1,0 +1,535 @@
+package GFFExon;
+use strict 'vars';
+use strict 'refs';
+
+require GFFTranscript;
+
+use GFFCDS;
+use GFFUTR;
+
+my $debug = 1;
+
+# use overload '==' => \&compare;
+
+sub new {
+	my ( $exon_name, $start_coord, $end_coord, $parent ) = @_;
+	my $self = { id => $exon_name,
+		     start => $start_coord,
+		     end => $end_coord,
+		     parent => $parent };
+			  		     
+	bless $self, GFFExon;
+	
+	return $self;
+}
+
+sub copy {
+	my ( $ref, $parent ) = @_;
+
+
+	my $self = {
+			id     => $ref->{id},
+			start  => $ref->{start},
+			end    => $ref->{end},
+			parent => $parent
+		};
+
+	bless $self, GFFExon;
+
+	# Copying other atrributes
+	$self->cpy_attrib($ref);
+	return $self;
+}
+
+sub cpy_attrib{
+	my $self = shift;
+	my ( $ref ) = @_;
+	
+	foreach my $ckey ( keys %{$ref->{attrib}} ){
+		$self->{attrib}{$ckey} = $ref->{attrib}{$ckey}
+	}
+}
+
+
+sub overlaps {
+	my $self = shift;
+	my ($other) = @_;
+	
+	return 0 if $self->get_chrom() ne $other->get_chrom();
+	return 0 if $self->get_strand() ne $other->get_strand();
+	
+	if( ( $self->get_start() >= $other->get_start && $self->get_start() <= $other->get_end() ) ||
+	    ( $other->get_start() >= $self->get_start && $other->get_start() <= $self->get_end() ) ){
+	    	return 1;
+	    }else{
+	    	return 0;
+	    }
+}
+
+sub overlaps_op_strand {
+	my $self = shift;
+	my ($other) = @_;
+	
+	return 0 if $self->get_chrom() ne $other->get_chrom();
+	return 0 if $self->get_strand() eq $other->get_strand();
+	
+	if( ( $self->get_start() >= $other->get_start && $self->get_start() <= $other->get_end() ) ||
+	    ( $other->get_start() >= $self->get_start && $other->get_start() <= $self->get_end() ) ){
+	    	return 1;
+	    }else{
+	    	return 0;
+	    }
+}
+
+
+
+sub identical {
+	my $self = shift;
+	my ($other) = @_;
+	
+	return 0 if $self->get_chrom() ne $other->get_chrom();
+	return 0 if $self->get_strand() ne $other->get_strand();
+	
+	if( $self->get_start() == $other->get_start && $self->get_end() == $other->get_end() ){
+	    	return 1;
+	    }else{
+	    	return 0;
+	    }
+}
+
+sub get_strand{
+	my $self = shift;
+	return $self->{parent}->get_strand();	
+}
+
+sub get_chrom{
+	my $self = shift;
+	return $self->{parent}->get_chrom();	
+}
+
+
+sub get_parent {
+	my $self = shift;
+	return $self->{parent};
+}
+
+sub is_last{
+	my $self = shift;
+	
+	#print "GFFExonUTRCDS::is_last   Parent ID " . $self->{parent}->get_id() . "\n";
+	#print "Last exon:" . $self->{parent}->get_last_exon()->get_id() . "  Current exon:" . $self->{id} . "\n";
+	
+	return $self->{id} eq $self->{parent}->get_last_exon()->get_id();
+}
+
+sub is_last_exon_strand_based{
+	my $self = shift;
+	
+	return $self->{id} eq $self->{parent}->get_last_exon_strand_based()->get_id();
+}	
+
+sub is_first_exon_strand_based{
+	my $self = shift;
+	
+	return $self->{id} eq $self->{parent}->get_first_exon_strand_based()->get_id();
+}	
+	
+
+sub is_first{
+	my $self = shift;
+	
+	#print "GFFExonUTRCDS::is_first   Parent ID " . $self->{parent}->get_id() . "\n";
+	#print "First exon:" . $self->{parent}->get_first_exon()->get_id() . "  Current exon:" . $self->{id} . "\n";
+	
+	return $self->{id} eq $self->{parent}->get_first_exon()->get_id();
+}
+
+
+sub has_same_start{
+	my $self = shift;
+
+	my ($other_exon_ref) = @_;
+
+	return 1 if( ( $self->{start} == $other_exon_ref->get_start() )  );
+		
+	return 0;
+}
+
+sub has_same_end{
+	my $self = shift;
+
+	my ($other_exon_ref) = @_;
+
+	return 1 if( ( $self->{end} == $other_exon_ref->get_end() )  );
+		
+	return 0;
+}
+
+
+sub is_compatible_to{
+	my $self = shift;
+
+	my ($other_exon_ref) = @_;
+
+	# Exons are compatible if:	
+	# - They are the last exons and start coordinates are identical
+	# - They are the first exons and end coordinates are identical
+	# - If they are neither the first nor the last exons but the coordinates are identical
+	# - Both exons are the single exon in the gene and they have identical CDS
+
+	# For the time being we are going compare only the same exon across different GFF files
+	# Therefore, if the exon id is different the exons are automatically incompatible	
+
+
+
+	# If both exons belong to a transcript with only one exon
+	# and the CDS are identical, those exons are considered 
+	# compatible
+	if ( $other_exon_ref->get_parent()->num_exons() == 1 &&
+	               $self->get_parent()->num_exons() == 1 ){
+	  my $other_cds = $other_exon_ref->get_CDS();
+	  my $self_cds  = $other_exon_ref->get_CDS();
+	  
+	  if( $other_cds->get_start() == $other_cds->get_start() &&
+	      $other_cds->get_end()   == $other_cds->get_end() ){
+	      return 1
+	  }else{
+	  	  return 0;
+	  }	  
+	}
+	
+	return 1 if( ( $self->{start} == $other_exon_ref->get_start() ) &&
+		     ( $self->{end} == $other_exon_ref->get_end() )  );
+	
+	return 1 if( $self->is_last() && $other_exon_ref->is_last() &&
+		     ( $self->{start} == $other_exon_ref->get_start() ) );
+
+	return 1 if( $self->is_first() && $other_exon_ref->is_first() &&
+		     ( $self->{end} == $other_exon_ref->get_end() ) );
+
+	
+	return 0;
+}
+
+sub get_id {
+	my $self = shift;
+	return $self->{id};
+}
+
+sub set_id {
+	my $self = shift;
+	
+	my ($new_id) = @_;
+	
+	$self->{id} = $new_id;
+}
+
+
+
+sub get_start {
+	my $self = shift;
+	return $self->{start};
+}
+	
+sub get_end {
+	my $self = shift;
+	return $self->{end};
+}
+
+sub get_length {
+	my $self = shift;
+	return $self->{end} - $self->{start};
+}
+
+
+sub set_start {
+	my $self = shift;
+	my ( $coord_start ) = @_;
+	
+	$self->{start} = $coord_start;
+	
+	foreach my $currUTR ( @{$self->{UTR}} ){  
+		$currUTR->set_start( $coord_start ) if( $currUTR->get_start() < $coord_start );
+		if( $currUTR->get_length() <= 0 ){
+			$self->get_parent()->delete_UTR_from_internal_array( $currUTR );
+			$self->dettach_UTR( $currUTR );
+		}			 
+	}
+	
+	if( defined $self->{CDS} ){	  
+		$self->{CDS}->set_start( $coord_start) if( $self->{CDS}->get_start() < $coord_start );
+	}  
+}
+	
+sub set_end {
+	my $self = shift;
+	my ( $coord_end ) = @_;
+	
+	$self->{end} = $coord_end;
+		
+	foreach my $currUTR ( @{$self->{UTR}} ){  
+		$currUTR->set_end( $coord_end) if( $currUTR->get_end() > $coord_end );		
+		if( $currUTR->get_length() <= 0 ){
+			$self->get_parent()->delete_UTR_from_internal_array( $currUTR );
+			$self->dettach_UTR( $currUTR );
+		}			 		
+	}
+	
+	if( defined $self->{CDS} ){
+		$self->{CDS}->set_end( $coord_end ) if( $self->{CDS}->get_end() > $coord_end );
+	}  	
+}
+
+sub toGFF {
+	my $self = shift;
+	
+	my ($chrom, $parent, $strand ) = @_;
+	
+	my $str = $chrom . "\t.\t" . "exon" . "\t" . 
+	      $self->{start} . "\t" . 
+	      $self->{end} . "\t.\t" . 
+	      $strand . "\t.\t" . 
+	      "ID=" . $self->{id} . ";" .
+      	      "Parent=$parent;\n";
+      	      
+    return $str;	
+}
+
+sub attach_UTR{
+	my $self = shift;
+
+	my ($utr_ref) = @_;
+	
+	push( @{$self->{UTR}}, $utr_ref );
+
+	$utr_ref->set_parent_exon( $self );
+}
+
+sub dettach_UTR{
+	my $self = shift;
+
+	my ($param_UTR) = @_;
+	
+	my $succesfuly_dettached = 0;
+	
+	for( my $arrInd = 0; $arrInd < scalar( @{$self->{UTR}} ); $arrInd++ ){
+		if( $param_UTR->get_id() eq $self->{UTR}->[ $arrInd ]->get_id() ){
+			
+			print STDERR "GFFExon::dettach_UTR ID param:" . $param_UTR->get_id() . "\n";
+			print STDERR "GFFExon::dettach_UTR ID found:" . $self->{UTR}->[ $arrInd ]->get_id()  . "\n";
+						
+			die "Something wrong! Exon " . $self->get_id() . " was reported as coding" .
+			    " exon, but there are no CDS attached!"  if( not defined( $self->{CDS} ) ); 
+									
+			splice @{$self->{UTR}}, $arrInd, 1;			
+			
+			$succesfuly_dettached = 1;
+			last;
+		}	
+	}	
+	
+	die "Unable to delete UTR from exon \'" . $self->get_id() . 
+	    "\' ! UTR not found!" 
+	    if $succesfuly_dettached == 0;  
+	
+}
+
+# Delete the CDS from the exon but do not make any change
+# in the UTR. !!!!! PRIVATE method !!!!!!
+sub delete_CDS_NO_UTR_CHANGES{
+	my $self = shift;
+	my ($param_CDS) = @_;
+
+	my $succesfuly_deleted = 0;
+		
+	die "Unable to delete CDS from exon \'" . $self->get_id() . 
+	    "\'! Exon does not have an CDS!" 
+	    if not $self->has_CDS();  
+
+	die "Unable to delete CDS from exon \'" . $self->get_id() . 
+	    "\'! Exon is non-coding!" 
+	    if $self->is_non_coding();  
+
+	print STDERR "Removing CDS: " . $self->get_id() . "\n" if $debug;
+		
+	for( my $arrInd = 0; $arrInd < scalar( @{$self->{CDS}} ); $arrInd++ ){
+		if( $param_CDS->get_id() eq $self->{CDS}->[ $arrInd ]->get_id() ){
+			
+			print STDERR "GFFExon::delete_CDS_NO_UTR_CHANGES ID param:" . $param_CDS->get_id() . "\n";
+			print STDERR "GFFExon::delete_CDS_NO_UTR_CHANGES ID found:" . $self->{CDS}->[ $arrInd ]->get_id()  . "\n";
+						
+			die "Something wrong! Exon " . $self->get_id() . " was reported as coding" .
+			    " exon, but there are no CDS attached!"  if( not defined( $self->{CDS} ) ); 
+									
+			splice @{$self->{CDS}}, $arrInd, 1;			
+			
+			$succesfuly_deleted = 1;
+			last;
+		}	
+	}
+
+	die "Unable to delete CDS from exon \'" . $self->get_id() . 
+	    "\' ! CDS not found!" 
+	    if $succesfuly_deleted == 0;  
+
+}
+
+
+sub delete_UTR{
+	my $self = shift;
+	my ($param_UTR) = @_;
+
+	my $succesfuly_deleted = 0;
+		
+	die "Unable to delete UTR from exon \'" . $self->get_id() . 
+	    "\'! Exon does not have an UTR!" 
+	    if not $self->has_UTR();  
+
+	die "Unable to delete UTR from exon \'" . $self->get_id() . 
+	    "\'! Exon is non-coding!" 
+	    if $self->is_non_coding();  
+
+		
+	for( my $arrInd = 0; $arrInd < scalar( @{$self->{UTR}} ); $arrInd++ ){
+		if( $param_UTR->get_id() eq $self->{UTR}->[ $arrInd ]->get_id() ){
+			
+			print STDERR "GFFExon::delete_UTR ID param:" . $param_UTR->get_id() . "\n";
+			print STDERR "GFFExon::delete_UTR ID found:" . $self->{UTR}->[ $arrInd ]->get_id()  . "\n";
+						
+			die "Something wrong! Exon " . $self->get_id() . " was reported as coding" .
+			    " exon, but there are no CDS attached!"  if( not defined( $self->{CDS} ) ); 
+						
+			# If UTR on upstream region of the exon
+			if ( $self->{UTR}->[ $arrInd ]->get_start() == $self->get_start() ){
+				$self->set_start( $self->{CDS}->get_start );
+			}elsif( $self->{UTR}->[ $arrInd ]->get_end() == $self->get_end() ){
+				$self->set_end( $self->{CDS}->get_end );
+			}else{
+				die "Something wrong on exon " . $self->get_id() . " ! UTR seems to be in the core of the EXON";
+			} 
+
+			print STDERR "GFFExon::delete_UTR Transcript numUTRs:" . $self->get_parent()->num_UTRs . "\n";
+			
+			
+			$succesfuly_deleted = 1;
+			last;
+		}	
+	}
+
+	die "Unable to delete UTR from exon \'" . $self->get_id() . 
+	    "\' ! UTR not found!" 
+	    if $succesfuly_deleted == 0;  
+
+}
+
+
+sub is_non_coding {
+	my $self = shift;
+	my ( $exon_param ) = @_;
+	
+	return 0 if not $self->has_UTR();
+	
+	foreach my $currUTR ( @{$self->{UTR}} ){  
+
+		return 1 if( $currUTR->get_start == $self->get_start() &&
+				     $currUTR->get_end   == $self->get_end()  );
+		
+	}
+	
+	return 0;
+}
+
+sub has_UTR{
+	my $self = shift;
+
+	return 1 if ( defined( $self->{UTR} ) && scalar( @{$self->{UTR}} ) != 0 );
+	return 0;
+}	
+
+sub has_up_UTR{
+	my $self = shift;		
+	foreach my $currUTR ( @{$self->{UTR}} ){
+		
+		    print STDERR "GFFExon::has_down_utr curr. UTR start: " . $currUTR->get_start() . "\n";
+		    print STDERR "GFFExon::has_down_utr curr. EXON start: " . $self->get_start() . "\n";		    
+		  		
+			return 1 if $currUTR->get_start() == $self->get_start();
+	}	
+	return 0;
+}	
+
+sub has_down_UTR{
+	my $self = shift;
+	foreach my $currUTR ( @{$self->{UTR}} ){  	
+		    print STDERR "GFFExon::has_down_utr curr. UTR end: " . $currUTR->get_end() . "\n";
+		    print STDERR "GFFExon::has_down_utr curr. EXON end: " . $self->get_end() . "\n";		    
+			return 1 if $currUTR->get_end() == $self->get_end();
+	}	
+	return 0;
+}	
+
+
+sub attach_CDS{
+	my $self = shift;
+
+	my ($cds_ref) = @_;	
+	$self->{CDS} = $cds_ref;
+	$cds_ref->set_parent_exon( $self );
+}
+
+sub get_UTR{
+	my $self = shift;
+	
+	my ($up_downstream) = @_;
+	
+	foreach my $currUTR ( @{$self->{UTR}} ){  		
+		if( $up_downstream eq "up" ){
+			return $currUTR if $currUTR->get_start() == $self->get_start()
+		}elsif( $up_downstream eq "down" ){
+			return $currUTR if $currUTR->get_end() == $self->get_end()
+		}
+	}	
+	
+	return 0;
+}
+
+sub get_CDS{
+	my $self = shift;	
+	return $self->{CDS};
+}
+
+sub has_CDS{
+	my $self = shift;
+	return 1 if defined( $self->{CDS} );
+	return 0;
+}	
+
+
+
+# sub compare{
+	# my $self = shift;
+	# 
+	# my ( $other ) = @_;
+	# 
+	# return 0 if( 	$self->{start} == $other->{start} && 
+			# $self->{end} == $other->{end}	  && 
+			# $self->{chrom} == $other->{end}	  && 
+	# 
+# }
+
+sub set_attribute {
+	my $self = shift;
+	my ( $key, $value ) = @_;
+	
+	return $self->{attrib}{$key} = $value;
+}
+
+
+sub get_attribute {
+	my $self = shift;
+	my ($key) = @_;
+	return $self->{attrib}{$key};
+}	
+
+	
+return 1;

--- a/scripts/GFFLib/GFFExonUTRCDS.pm
+++ b/scripts/GFFLib/GFFExonUTRCDS.pm
@@ -1,0 +1,142 @@
+package GFFExonUTRCDS;
+use strict 'vars';
+use strict 'refs';
+
+require GFFLib::GFFTranscript;
+
+# use overload '==' => \&compare;
+
+sub new {
+# type = [exon,five_prime_utr,three_prime_utr,CDS]	
+	my ( $exon_name, $start_coord, $end_coord, $type, $parent ) = @_;
+	my $self = { id => $exon_name,
+		     start => $start_coord,
+		     end => $end_coord,
+		     type => $type,
+		     parent => $parent };
+			  
+	bless $self, GFFExonUTRCDS;
+	
+	return $self;
+}
+
+sub get_parent {
+	my $self = shift;
+	return $self->{parent};
+}
+
+# type = [exon,five_prime_utr,three_prime_utr,CDS]	
+sub is_last{
+	my $self = shift;
+	
+	print "GFFExonUTRCDS::is_last   Parent ID " . $self->{parent}->get_id() . "\n";
+	print "Last exon:" . $self->{parent}->get_last( $self->{type} )->get_id() . "  Current:" . $self->{id} . "\n";
+	
+	return $self->{id} eq $self->{parent}->get_last( $self->{type} )->get_id();
+}
+
+sub is_first{
+	my $self = shift;
+	
+	print "GFFExonUTRCDS::is_first   Parent ID " . $self->{parent}->get_id() . "\n";
+	print "First exon:" . $self->{parent}->get_first( $self->{type} )->get_id() . "  Current:" . $self->{id} . "\n";
+	
+	return $self->{id} eq $self->{parent}->get_first( $self->{type} )->get_id();
+}
+
+sub is_compatible_to{
+	my $self = shift;
+
+	my ($other_exon_ref) = @_;
+
+	# Exons are compatible if:	
+	# - They are the last exons and start coordinates are identical
+	# - They are the first exons and end coordinates are identical
+	# - If they are neither the first nor the last exons but the coordinates are identical
+
+	# For the time being we are going compare only the same exon across different GFF files
+	# Therefore, if the exon id is different the exons are automatically incompatible	
+	
+	return 1 if( ( $self->{start} == $other_exon_ref->get_start() ) &&
+		     ( $self->{end} == $other_exon_ref->get_end() )  );
+	
+	return 1 if( $self->is_last_exon() && $other_exon_ref->is_last_exon() &&
+		     ( $self->{start} == $other_exon_ref->get_start() ) );
+
+	return 1 if( $self->is_first_exon() && $other_exon_ref->is_first_exon() &&
+		     ( $self->{end} == $other_exon_ref->get_end() ) );
+
+	
+	return 0;
+}
+
+sub get_id {
+	my $self = shift;
+	return $self->{id};
+}
+
+
+sub get_start {
+	my $self = shift;
+	return $self->{start};
+}
+	
+sub get_end {
+	my $self = shift;
+	return $self->{end};
+}
+
+sub set_start {
+	my $self = shift;
+	my ( $coord_start ) = @_;
+	
+	return $self->{start} = $coord_start;
+}
+	
+sub set_end {
+	my $self = shift;
+	my ( $coord_end ) = @_;
+	
+	return $self->{end} = $coord_end;
+}
+
+sub toGFF {
+	my $self = shift;
+	
+	my ($chrom, $parent, $strand ) = @_;
+	
+	print $chrom . "\t.\t" . $self->{type} . "\t" . 
+	      $self->{start} . "\t" . 
+	      $self->{end} . "\t.\t" . 
+	      $strand . "\t.\t" . 
+	      "ID=" . $self->{id} . "; " .
+      	      "Parent=$parent;\n";	
+}
+
+# sub compare{
+	# my $self = shift;
+	# 
+	# my ( $other ) = @_;
+	# 
+	# return 0 if( 	$self->{start} == $other->{start} && 
+			# $self->{end} == $other->{end}	  && 
+			# $self->{chrom} == $other->{end}	  && 
+	# 
+# }
+
+sub set_attribute {
+	my $self = shift;
+	my ( $key, $value ) = @_;
+	
+	return $self->{attrib}{$key} = $value;
+}
+
+
+sub get_attribute {
+	my $self = shift;
+	my ($key) = @_;
+	return $self->{attrib}{$key};
+}	
+
+	
+return 1;

--- a/scripts/GFFLib/GFFFile.pm
+++ b/scripts/GFFLib/GFFFile.pm
@@ -1,0 +1,944 @@
+package GFFFile;
+use strict 'vars';
+use strict 'refs';
+
+use GFFGene;
+use Data::Dumper;
+use Carp;
+
+#use Carp::Always;
+
+$Carp::Verbose = 1;
+
+#############
+# Constants
+my $debug = 0;
+
+my $GENE       = "gene";
+my $PSEUDOGENE = "pseudogene";
+my $MUORF      = "uORF";
+
+# Transcript types
+my $TRANSCRIPT  = "transcript";
+my $MRNA        = "mRNA";
+my $NCRNA       = "ncRNA";
+my $RRNA        = "rRNA";
+my $TRNA        = "tRNA";
+my $PSEUDO_TRNA = "pseudotRNA";
+my $SNRNA       = "snRNA";
+my $SCRNA       = "scRNA_encoding";
+my $SNORNA      = "snoRNA";
+my $MIRNA       = "miRNA";
+my $MISCRNA     = "misc_RNA";
+my $EXON        = "exon";
+
+my $NON_CODING_EXON     			= "noncoding_exon";
+my $CDS  = "CDS";
+my $UTR5 = "five_prime_UTR";
+my $UTR3 = "three_prime_UTR";
+
+# Genomeview and Ergatis do not like individual IDs for CDS.
+# According to those applications those features should share the same ID if
+# they belong to the same transcript.
+# If the constant below is set to 1, this directive will be imposed when assigng IDs to
+# those features.
+my $individual_CDS_ids = 1;
+
+sub new {
+	my ($filename) = @_;
+	my %chroms;
+	my $self = { filename => $filename,
+				 chroms => %chroms };
+	
+	bless $self, GFFFile;
+	
+	return $self;
+}
+
+sub get_header_comments{
+	my $self = shift;
+	return $self->{header_comments};	
+}
+
+sub add_exon_to_index {
+	my $self = shift;
+	
+	my ($exon_id, $transcript_id, $gene_id ) = @_;
+	
+	$self->{exon_index}->{$exon_id} = {
+		transcript => $transcript_id,
+		gene       => $gene_id
+	};
+}
+
+sub get_filename {
+	my $self = shift;
+	return $self->{filename};
+}
+
+sub get_chrom_names {
+	my $self = shift;
+	return keys (%{$self->{chroms}});
+}
+
+
+sub read {
+	my $self = shift;
+	
+	# Add missing features:
+	# - add missing genes, transcripts and exons from existing CDS
+	# - genes exons or CDS (NOT IMPLEMENTED)
+	# - transcripts from exon or CDS (NOT IMPLEMENTED)
+	# - exons from CDS (NOT IMPLEMENTED)
+	
+	my ( $discard_additional_attributes, $add_missing ) = @_;
+		
+	print STDERR "Reading genes...\n";
+	$self->read_genes( $discard_additional_attributes, $add_missing );
+	print STDERR "Reading transcripts...\n";
+	$self->read_transcripts( $discard_additional_attributes, $add_missing );
+	print STDERR "Reading exons...\n";
+	$self->read_exons( $discard_additional_attributes, $add_missing );
+	print STDERR "Reading UTRs...\n";
+	$self->read_utrs( $discard_additional_attributes, $add_missing );
+	print STDERR "Reading CDS...\n";
+	$self->read_cds( $discard_additional_attributes, $add_missing );
+	print STDERR "Post-processing...\n";
+	$self->post_processing($add_missing);
+}
+
+sub read_genes {
+	my $self = shift;
+	
+	my ( $discard_additional_attributes, $add_missing ) = @_;
+	
+	open GFFin, $self->{filename}
+	or croak "Unable to open file \'" . $self->{filename} . "\' for reading\n";
+	
+	# Reading only genes
+	my $still_on_header = 1;
+	while (<GFFin>) {
+		my $line = $_;
+		
+		if ( $line =~ /^\#\#FASTA/ ){
+			last;
+		} 
+		
+		if ( $line =~ /^\#/ && $still_on_header){
+			$self->{header_comments} .= $line; 
+			next;
+		}
+		next if ( $line =~ /^\#/ || $line =~ /^\s+$/ );
+		$still_on_header = 0;
+		
+		my (
+			$chrom,  $feature,     $start, $end,
+			$strand, $phase,       $id,    $parent,
+			$name,   $description, $attribRef
+			) = process_line($line);
+			
+			
+			$self->{chroms}{$chrom} = 1;
+			
+			my %attr = %{$attribRef};
+			
+			# Reference to the new feature
+			# Used in the iteration to innitialize values and call methods
+			# shared by all different type of features
+			my $temp_feature;
+			
+			print STDERR "Line describes feature: $feature\n" if $debug;
+			if (   $feature eq $GENE
+				|| $feature eq $PSEUDOGENE
+				|| $feature eq $MUORF )
+			{
+				print STDERR "Processing line:\n\t$line\n" if $debug;
+				print STDERR "Gene: $id\n"                 if $debug;
+				getc()                                     if $debug;
+				
+				$name = $id if $name eq "";
+				
+				$temp_feature =
+				GFFGene::new( $id, $name, $chrom, $start, $end, $strand, $self );
+				$temp_feature->set_filename( $self->{filename} );
+				$temp_feature->set_description($description);
+				
+				$self->{genes}->{$id} = $temp_feature;
+				$self->{chrom_index}->{$chrom}->{$id} = $temp_feature;
+				
+				#######################################
+				## General initialization of features
+				
+				# Set additional attributes
+				if ( $discard_additional_attributes == 0 )
+				{
+					foreach my $currKey ( keys %attr ) {
+						$temp_feature->set_attribute( $currKey, $attr{$currKey} );
+					}
+				}
+			}
+	}
+	close(GFFin);
+}
+
+sub read_transcripts {
+	
+	my $self = shift;
+	
+	my ( $discard_additional_attributes, $add_missing ) = @_;
+	
+	# Reading only transcripts
+	open GFFin, $self->{filename}
+	or croak "Impossible to open file " . $self->{filename} . " for read\n";
+	while (<GFFin>) {
+		my $line = $_;
+		
+		if ( $line =~ /^\#\#FASTA/ ){
+			last;
+		} 
+		
+		next if ( $line =~ /^\#/ || $line =~ /^\s+$/ );
+		
+		my (
+			$chrom,  $feature,     $start, $end,
+			$strand, $phase,       $id,    $parent,
+			$name,   $description, $attribRef
+			) = process_line($line);
+			
+			$self->{chroms}{$chrom} = 1;			
+			my %attr = %{$attribRef};
+			
+			# Reference to the new feature
+			# Used in the iteration to innitialize values and call methods
+			# shared by all different type of features
+			my $temp_feature;
+			
+			if (   $feature eq $TRANSCRIPT
+				|| $feature eq $MRNA
+				|| $feature eq $RRNA
+				|| $feature eq $TRNA
+				|| $feature eq $SCRNA
+				|| $feature eq $SNRNA
+				|| $feature eq $SNORNA
+				|| $feature eq $MIRNA
+				|| $feature eq $MISCRNA
+				|| $feature eq $NCRNA
+				|| $feature eq $PSEUDO_TRNA )
+			{
+				
+				print STDERR "Processing line:\n\t$line\n"      if $debug;
+				print STDERR "Transcript: $id\tGene: $parent\n" if $debug;
+				getc()                                          if $debug;
+				
+				
+				if ( $parent eq '' || not defined $self->{genes}->{$parent} ) {
+					if ( $add_missing != 0 ) {
+						
+						my $gene_name = $id . "-G";
+						my $gene_id   = $id . "-G";
+						
+						my $gene_temp_feature =
+						GFFGene::new( $gene_id, $gene_name, $chrom, $start, $end,
+							$strand, $self );
+						$gene_temp_feature->set_filename( $self->{filename} );
+						$self->{genes}->{$gene_id} = $gene_temp_feature;
+						$self->{chrom_index}->{$chrom}->{$gene_id} =
+						$gene_temp_feature;
+						
+				
+				if ( $discard_additional_attributes == 0 )
+				{
+					foreach my $currKey ( keys %attr ) {
+						$gene_temp_feature->set_attribute( $currKey, $attr{$currKey} );
+					}
+				}						
+						
+						$parent = $gene_id;
+					}else{
+						if( $parent eq '' ){
+							croak "Error on file \'"
+							. $self->{filename}
+							. "\' : The transcript $id does not seem to have a parent\n";
+						}else{
+							croak "Error on file \'"
+							. $self->{filename}
+							. "\' : Unable to find parent of $id, looking for $parent\n";
+							
+							
+						}
+					}
+				}
+				
+				$temp_feature =
+				$self->{genes}->{$parent}
+				->add_transcript( $id, $feature, $start, $end );
+				$self->{transcript_index}->{$id} = $parent;
+				
+				#######################################
+				## General initialization of features
+				# Set additional attributes
+				
+				#Set additional attributes
+				#print ">>>>$discard_additional_attributes<<\n";
+				#getc();
+							
+				if ( $discard_additional_attributes == 0 )
+				{
+					foreach my $currKey ( keys %attr ) {
+						$temp_feature->set_attribute( $currKey, $attr{$currKey} );						
+					}
+				}
+				
+			}
+			
+	}
+	close(GFFin);
+}
+
+sub read_exons {
+	my $self = shift;
+	my ( $discard_additional_attributes, $add_missing ) = @_;
+	
+	# Reading exons
+	open GFFin, $self->{filename}
+	or croak "Impossible to open file " . $self->{filename} . " for read\n";
+	while (<GFFin>) {
+		my $line = $_;
+		
+		if ( $line =~ /^\#\#FASTA/ ){
+			last;
+		} 		
+		
+		next if ( $line =~ /^\#/ || $line =~ /^\s+$/ );
+		
+		print STDERR "Processing line:\n\t$line\n" if $debug;
+		my (
+			$chrom,  $feature,     $start, $end,
+			$strand, $phase,       $id,    $parent,
+			$name,   $description, $attribRef
+			) = process_line($line);
+			
+			$self->{chroms}{$chrom} = 1;			
+			my %attr = %{$attribRef};
+			
+			# Reference to the new feature
+			# Used in the iteration to innitialize values and call methods
+			# shared by all different type of features
+			my $temp_feature;
+			
+			next
+			if ( $feature ne $EXON && $feature ne $NON_CODING_EXON);
+			
+			# The standard GFF format accepts multiple exon Parents, if separated by comma
+			my @parents = split ",", $parent;
+			
+			foreach my $curr_parent (@parents) {
+				
+				my $curr_transcript = $curr_parent;
+				my $curr_gene_name =
+				$self->get_gene_name_by_transcript_name($curr_transcript);
+				
+				if ( not defined($curr_gene_name) ) {
+					
+					if ( not $add_missing ) {
+						croak "Unable to find the transcript and gene associated to"
+						. " the exon ID=$id NAME=$name using as parent PARENT=$curr_parent\n";
+					}
+					else {
+						
+						my $temp_gene = $self->get_gene($curr_parent);
+						
+						# If does not have a transcript but has a gene
+						if ( defined($temp_gene) ) {
+							print STDERR
+							"Adding missing transcript to an oprhan exon \'$id\' associate to gene \'$curr_parent\'\n";
+							
+							my $gene_id = $curr_parent;
+							
+							# Create new transcript
+							my $transcript_id     = $gene_id . "-T";
+							my $temp_gene_feature = $self->{genes}->{$gene_id};
+							
+							$temp_gene_feature->add_transcript(
+								$transcript_id, "mRNA",
+								$temp_gene_feature->get_start(),
+								$temp_gene_feature->get_end()
+								);
+							$self->{transcript_index}->{$transcript_id} = $gene_id;
+							
+							$curr_gene_name  = $gene_id;
+							$curr_transcript = $transcript_id;
+							
+						}
+						else {
+							print STDERR
+							"Adding missing gene, transcript to orphan exon \'$id\'\n";
+							
+							#Generate a random gene id
+							my $gene_id = "tmp_gene_" . int( rand(10000) );
+							while ( defined $self->{genes}->{$gene_id} ) {
+								$gene_id = "tmp_gene_" . int( rand(10000) );
+							}
+							
+							my $temp_gene_feature =
+							GFFGene::new( $gene_id, $gene_id, $chrom, $start,
+								$end, $strand, $self );
+							$temp_gene_feature->set_filename( $self->{filename} );
+							$self->{genes}->{$gene_id} = $temp_gene_feature;
+							$temp_gene_feature->set_attribute( "Alias",
+								$attr{Alias} );
+							
+							# Transfering attribute from EXON to GENE
+							foreach my $currKey ( keys %attr ) {
+								$temp_gene_feature->set_attribute( $currKey,
+									$attr{$currKey} );
+							}
+							
+							$self->{chrom_index}->{$chrom}->{$id} =
+							$temp_gene_feature;
+							
+							# Create new transcript
+							my $transcript_id = $gene_id . "-T";
+							$self->{genes}->{$gene_id}
+							->add_transcript( $transcript_id,
+								"mRNA", $start, $end );
+							$self->{transcript_index}->{$transcript_id} = $gene_id;
+							
+							$curr_gene_name  = $gene_id;
+							$curr_transcript = $transcript_id;
+							
+						}
+					}
+				}
+				
+				# If exon doesn't have a name create one or $force_idchange_transcript_exon_cds == 1
+				if ( $id eq "" ) {
+					$id =
+					$parent . "-E"
+					. ( $self->{genes}->{$curr_gene_name}
+						->get_transcript($curr_transcript)->num_exons() + 1 );
+				}
+				print STDERR
+				"Exon: $id\tTranscript: $curr_transcript\tGene: $curr_gene_name\n"
+				if $debug;
+				
+				$temp_feature =
+				$self->{genes}->{$curr_gene_name}
+				->get_transcript($curr_transcript)->add_exon( $id, $start, $end );
+				$self->{exon_index}->{$id} = {
+					transcript => $curr_transcript,
+					gene       => $self->{transcript_index}->{$curr_transcript}
+				};
+			}
+			
+			#######################################
+			## General initialization of features
+			
+			#	print "Setting attributes >>>$discard_additional_attributes ....\n";
+			#	getc();
+			
+			# Set additional attributes
+			#if( $discard_additional_attributes == 0 ){
+			foreach my $currKey ( keys %attr ) {
+				$temp_feature->set_attribute( $currKey, $attr{$currKey} );
+			}
+			
+			#	print "Setting attributes ....\n";
+			#	getc();
+			#}
+			getc() if $debug;
+			
+	}
+	
+	close(GFFin);
+	
+}
+
+sub read_utrs {
+	my $self = shift;
+	my ( $discard_additional_attributes, $add_missing ) = @_;
+	
+	# Reading exons and CDS
+	open GFFin, $self->{filename}
+	or croak "Impossible to open file " . $self->{filename} . " for read\n";
+	while (<GFFin>) {
+		my $line = $_;
+		
+		if ( $line =~ /^\#\#FASTA/ ){
+			last;
+		} 
+		
+		
+		next if ( $line =~ /^\#/ || $line =~ /^\s+$/ );
+		
+		print STDERR "Processing line:\n\t$line\n" if $debug;
+		my (
+			$chrom,  $feature,     $start, $end,
+			$strand, $phase,       $id,    $parent,
+			$name,   $description, $attribRef
+			) = process_line($line);
+			
+			$self->{chroms}{$chrom} = 1;			
+			my %attr = %{$attribRef};
+			
+			# Reference to the new feature
+			# Used in the iteration to innitialize values and call methods
+			# shared by all different type of features
+			my $temp_feature;
+			
+			next
+			if ( uc($feature) ne uc($UTR5)
+				&& uc($feature) ne uc($UTR3) );
+			
+			if ( uc($feature) eq uc($UTR5) ) {
+				my $curr_gene_name =
+				$self->get_gene_name_by_transcript_name($parent);
+				
+				# If it doesn't have a name create one
+				if ( $id eq "" ) {
+					$id =
+					$parent . "-UTR"
+					. ( $self->{genes}->{$curr_gene_name}->get_transcript($parent)
+						->num_UTRs() + 1 );
+				}
+				print STDERR
+				"UTR5: $id\tTranscript: $parent\tGene: $curr_gene_name\n"
+				if $debug;
+				
+				$temp_feature =
+				$self->{genes}->{$curr_gene_name}->get_transcript($parent)
+				->add_5UTR( $id, $start, $end );
+			}
+			
+			if ( uc($feature) eq uc($UTR3) ) {
+				my $curr_gene_name =
+				$self->get_gene_name_by_transcript_name($parent);
+				
+				# If it doesn't have a name create one
+				if ( $id eq "" ) {
+					$id =
+					$parent . "-UTR"
+					. ( $self->{genes}->{$curr_gene_name}->get_transcript($parent)
+						->num_UTRs() + 1 );
+				}
+				print STDERR
+				"UTR3: $id\tTranscript: $parent\tGene: $curr_gene_name\n"
+				if $debug;
+				
+				$temp_feature =
+				$self->{genes}->{$curr_gene_name}->get_transcript($parent)
+				->add_3UTR( $id, $start, $end );
+			}
+			
+			#######################################
+			## General initialization of features
+			
+			#	print "Setting attributes >>>$discard_additional_attributes ....\n";
+			#	getc();
+			
+			# Set additional attributes
+			#if( not defined( $discard_additional_attributes ) ||
+			#    ( defined( $discard_additional_attributes ) && $discard_additional_attributes == 0 ) ){
+			foreach my $currKey ( keys %attr ) {
+				$temp_feature->set_attribute( $currKey, $attr{$currKey} );
+			}
+			
+			#	print "Setting attributes ....\n";
+			#	getc();
+			#}
+			getc() if $debug;
+	}
+	
+	close(GFFin);
+	
+}
+
+sub read_cds {
+	my $self = shift;
+	my ( $discard_additional_attributes, $add_missing ) = @_;
+	
+	# Reading exons and CDS
+	open GFFin, $self->{filename}
+	or croak "Impossible to open file " . $self->{filename} . " for read\n";
+	while (<GFFin>) {
+		my $line = $_;
+		
+		if ( $line =~ /^\#\#FASTA/ ){
+			last;
+		} 		
+		
+		next if ( $line =~ /^\#/ || $line =~ /^\s+$/ );
+		
+		print STDERR "Processing line:\n\t$line\n" if $debug;
+		my (
+			$chrom,  $feature,     $start, $end,
+			$strand, $phase,       $id,    $parent,
+			$name,   $description, $attribRef
+			) = process_line($line);
+			
+			$self->{chroms}{$chrom} = 1;			
+			my %attr = %{$attribRef};
+			
+			# Reference to the new feature
+			# Used in the iteration to innitialize values and call methods
+			# shared by all different type of features
+			my $temp_feature;
+			
+			next
+			if ( $feature ne $CDS );
+			
+			my $curr_gene_name = $self->get_gene_name_by_transcript_name($parent);
+			
+			if ( not defined($curr_gene_name) ) {
+				
+				if ( not $add_missing ) {
+					croak "Unable to find the transcript and gene associated to"
+					. " the CDS ID=$id NAME=$name using as parent PARENT=$parent\n";
+				}
+				else {
+					
+					my $temp_gene = $self->get_gene($parent);
+					
+					# If does not have a transcript but has a gene
+					if ( defined($temp_gene) ) {
+						print STDERR
+						"Adding missing transcript to an oprhan CDS \'$id\' associate to gene \'$parent\'\n";
+						
+						my $gene_id = $parent;
+						
+						# Check if this gene already have an transcript
+						# if it has more than one transcript than DIE, impossible to
+						# define which transcript the exon will be associated too
+						
+						my $temp_gene_feature = $self->{genes}->{$gene_id};
+						
+						my $num_transcripts = $temp_gene_feature->get_num_transcripts();
+						
+						if ( $num_transcripts == 1 ) {
+							my @trans_arr =
+							$temp_gene_feature->get_transcripts_array();
+							my $temp_transcript = $trans_arr[0];
+							
+							croak
+							"Undefined value for the first transcript of gene $gene_id\n"
+							if not defined($temp_transcript);
+							
+							$curr_gene_name = $gene_id;
+							$parent         = $temp_transcript->get_id();
+							
+							# If there is no transcripts than create one
+						}
+						elsif ( $num_transcripts == 0 ) {
+							
+							# Create new transcript
+							my $transcript_id = $gene_id . "-T";
+							
+							my $temp_transcript =
+							$temp_gene_feature->add_transcript(
+								$transcript_id, "mRNA",
+								$temp_gene_feature->get_start(),
+								$temp_gene_feature->get_end()
+								);
+							$self->{transcript_index}->{$transcript_id} = $gene_id;
+							
+							$curr_gene_name = $gene_id;
+							$parent         = $transcript_id;
+						}
+						else {
+							croak
+							"ERROR: Attempting to associate orphan CDS $id to a transcript of gene $gene_id.\n"
+							. "But this genes has multiple transcripts (" . $num_transcripts . " transcripts), impossible to define which one will be\n"
+							. "associated to the orphan CDS\n";
+						}
+						
+					}
+					elsif ( not defined($temp_gene) ) {
+						
+						# Assuming that CDS represents the whole gene, since there are no gene
+						# associated with it.
+						# Add missing gene, transcript and EXON
+						
+						print STDERR
+						"Adding missing gene, transcript and exon based on orphan CDS \'$id\'\n";
+						
+						#Generate a random gene id
+						my $gene_id = "tmp_gene_" . int( rand(10000) );
+						while ( defined $self->{genes}->{$gene_id} ) {
+							$gene_id = "tmp_gene_" . int( rand(10000) );
+						}
+						
+						#Generate a gene id based on CDS id
+						#my $gene_id = "$id:$start:$end-gene";
+						
+						my $temp_gene_feature =
+						GFFGene::new( $gene_id, $gene_id, $chrom, $start, $end,
+							$strand, $self );
+						$temp_gene_feature->set_filename( $self->{filename} );
+						$self->{genes}->{$gene_id} = $temp_gene_feature;
+						$temp_gene_feature->set_attribute( "Alias", $attr{Alias} );
+						
+						# Transfering attribute from CDS to GENE
+						foreach my $currKey ( keys %attr ) {
+							$temp_gene_feature->set_attribute( $currKey,
+								$attr{$currKey} );
+						}
+						
+						$self->{chrom_index}->{$chrom}->{$id} = $temp_gene_feature;
+						
+						# Create new transcript
+						my $transcript_id = $gene_id . "-T";
+						$self->{genes}->{$gene_id}
+						->add_transcript( $transcript_id, "mRNA", $start, $end );
+						$self->{transcript_index}->{$transcript_id} = $gene_id;
+						
+						# Create new exon
+						my $exon_id = $gene_id . "-E";
+						$self->{genes}->{$gene_id}->get_transcript($transcript_id)
+						->add_exon( $exon_id, $start, $end );
+						$self->{exon_index}->{$exon_id} = {
+							transcript => $transcript_id,
+							gene       => $gene_id
+						};
+						
+						$parent         = $transcript_id;
+						$curr_gene_name = $gene_id;
+					}
+				}
+			}
+			
+			# If it doesn't have a name create one
+			if ( $id eq "" ) {
+				my $serial_num = "";
+				$serial_num =
+				( $self->{genes}->{$curr_gene_name}->get_transcript($parent)
+					->num_CDSs() + 1 )
+				if not $individual_CDS_ids;
+				$id = $parent . "-P" . $serial_num;
+			}
+			print STDERR "CDS: $id\tTranscript: $parent\tGene: $curr_gene_name\n"
+			if $debug;
+			
+			$temp_feature =
+			$self->{genes}->{$curr_gene_name}->get_transcript($parent)
+			->add_CDS( $id, $start, $end, $phase );
+			
+			
+			#######################################
+			## General initialization of features
+			
+			#	print "Setting attributes >>>$discard_additional_attributes ....\n";
+			#	getc();
+			
+			# Set additional attributes
+			#if( not defined( $discard_additional_attributes ) ||
+			#    ( defined( $discard_additional_attributes ) && $discard_additional_attributes == 0 ) ){
+			foreach my $currKey ( keys %attr ) {
+				$temp_feature->set_attribute( $currKey, $attr{$currKey} );
+			}
+			
+			#	print "Setting attributes ....\n";
+			#	getc();
+			#}
+			getc() if $debug;
+	}
+	
+	close(GFFin);
+	
+}
+
+sub toGFF {
+	my $self = shift;
+	my $str  = "";
+	for my $currGene ( values %{ $self->{genes} } ) {
+		$str .= $currGene->toGFF();
+	}
+	return $str;
+}
+
+sub write {
+	my $self = shift;
+	my ($filename) = @_;
+	
+	open GFFout, ">$filename"
+	or croak "Impossible to open file " . $filename . " for write\n";
+	
+	print GFFout $self->toGFF();
+	
+	close(GFFout);
+}
+
+sub post_processing {
+	my $self = shift;
+	my ($add_missing) = @_;
+	for my $currGene ( values %{ $self->{genes} } ) {
+		
+		if ( not defined( $currGene->get_transcripts_hash() ) ) {
+			
+			if ( $add_missing == 0 ) {
+				warn "Warning: Gene "
+				. $currGene->get_id()
+				. " has no transcript. It will be removed!\n";
+				delete( $self->{genes}{ $currGene->get_id() } );
+				next;
+				
+			}
+			else {
+				
+				# Create new transcript
+				my $gene_id = $currGene->get_id();
+				my $start   = $currGene->get_start();
+				my $end     = $currGene->get_end();
+				
+				my $transcript_id = $gene_id . "-T";
+				$self->{genes}->{$gene_id}
+				->add_transcript( $transcript_id, "mRNA", $start, $end );
+				$self->{transcript_index}->{$transcript_id} = $gene_id;
+				
+				# Create new exon
+				my $exon_id = $gene_id . "-E";
+				$self->{genes}->{$gene_id}->get_transcript($transcript_id)
+				->add_exon( $exon_id, $start, $end );
+				$self->{exon_index}->{$exon_id} = {
+					transcript => $transcript_id,
+					gene       => $gene_id
+				};
+				
+			}
+		}
+		
+		for my $currTrans ( values %{ $currGene->get_transcripts_hash() } ) {
+			$currTrans->post_processing($add_missing);
+		}
+	}
+}
+
+sub get_genes_hash {
+	my $self = shift;
+	return $self->{genes};
+}
+
+sub get_genes_hash_by_chrom {
+	my $self = shift;
+	my ($chrom) = @_;
+	return $self->{chrom_index}->{$chrom};
+}
+
+sub get_gene {
+	my $self = shift;
+	my ($gene_name) = @_;
+	return $self->{genes}->{$gene_name};
+}
+
+sub get_gene_name_by_exon_name {
+	my $self = shift;
+	my ($exon_name) = @_;
+	return $self->{exon_index}->{$exon_name}{gene};
+}
+
+sub get_gene_name_by_transcript_name {
+	my $self = shift;
+	my ($transcript_name) = @_;
+	return $self->{transcript_index}->{$transcript_name};
+}
+
+sub get_gene_by_exon_name {
+	my $self = shift;
+	my ($exon_name) = @_;
+	
+	my $gene_name = $self->{exon_index}->{$exon_name}{gene};
+	return $self->{genes}->{$gene_name};
+}
+
+sub get_gene_by_transcript_name {
+	my $self = shift;
+	my ($transcript_name) = @_;
+	
+	my $gene_name = $self->{transcript_index}->{$transcript_name};
+	return $self->{genes}->{$gene_name};
+}
+
+sub get_transcript_by_name {
+	my $self = shift;
+	my ($transcript_name) = @_;
+	
+	#print ">>>>" . $transcript_name . "<<<<<\n";
+	#print Dumper( $self->get_gene_by_transcript_name( $transcript_name ) );
+	#getc();
+	my $gene = $self->get_gene_by_transcript_name($transcript_name);
+	return 0 if ( not defined $gene );
+	
+	return $gene->get_transcript($transcript_name);
+}
+
+sub get_transcript_by_exon_name {
+	my $self = shift;
+	my ($exon_name) = @_;
+	
+	#print ">>>>" . $exon_name . "<<<<<\n";
+	#print Dumper( $self->{exon_index}->{$exon_name} );
+	#getc();
+	
+	my $gene_name = $self->{exon_index}->{$exon_name}->{gene};
+	return undef if not defined($gene_name);
+	
+	my $transcript_name = $self->{exon_index}->{$exon_name}->{transcript};
+	return undef if not defined($transcript_name);
+	
+	return $self->{genes}->{$gene_name}->get_transcript($transcript_name);
+}
+
+return 1;
+
+sub process_line {
+	my ($line) = @_;
+	
+	if (
+		(
+			my (
+				$chrom, $void1,  $feature, $start, $end,
+				$void2, $strand, $phase, $info
+				)
+			= split "\t", $line
+			) == 9
+		)
+	{
+		
+		my ($id)     = ( $info =~ /ID=([\w\W]+?)[;\n]/ );
+		my ($parent) = ( $info =~ /Parent=([\w\W]+?)[;\n]/ );
+		my ($name)   = ( $info =~ /Name=([\w\W]+?)[;\n]/ );
+		
+		chomp($info);
+		
+		#Retrieving all attributes associated to the feature
+		my %attr;
+		my @separate_semicolon = split ";", $info;
+		foreach my $currAttr (@separate_semicolon) {
+			my ( $key, $value );
+			if ( ( $key, $value ) = ( $currAttr =~ /\s*([\w\W]+?)=([\w\W]+)/ ) )
+			{
+				#				if (   $key ne "ID"
+				#					&& $key ne "Parent"
+				#					&& $key ne "Name" )
+				#				{
+				$attr{$key} = $value;
+				#				}
+			}
+		}
+		
+		# Same description stores the gene product
+		my ($description) = ( $info =~ /description=([\w\W]+?)[;\n]/ );
+		
+		return (
+			$chrom,  $feature,     $start, $end,
+			$strand, $phase,       $id,    $parent,
+			$name,   $description, \%attr
+			);
+	}
+	else {
+		print STDERR
+		"\nThe following line does not have 9 columns separated by <tab>, a GFF format requirement.\n";
+		print STDERR
+		"Check if the columns are seperated by multiple <spaces> instead.\n";
+		croak "$line";
+	}
+}

--- a/scripts/GFFLib/GFFGene.pm
+++ b/scripts/GFFLib/GFFGene.pm
@@ -1,0 +1,288 @@
+package GFFGene;
+use strict 'vars';
+use strict 'refs';
+
+use GFFTranscript;
+
+sub new {
+	my ( $gene_id, $gene_name, $chrom, $start_coord, $end_coord, $strand, $file ) = @_;
+	my $self = {
+		id     => $gene_id,
+		name   => $gene_name,
+		chrom  => $chrom,
+		start  => $start_coord,
+		end    => $end_coord,
+		strand => $strand,
+		file   => $file
+	};
+	bless $self, GFFGene;
+
+	return $self;
+}
+
+sub get_file{
+	my $self = shift;
+	return $self->{file};
+}
+
+
+sub set_filename {
+	my $self = shift;
+	my ($filename) = @_;
+	$self->{filename} = $filename;
+}
+
+sub get_filename {
+	my $self = shift;
+	return $self->{filename};
+}
+
+sub overlaps {
+	my $self = shift;
+
+	# $strand_based = [op_strand, same_strand, strandness]
+	my ( $other, $strand_based, $buffer ) = @_;
+
+	return 0 if $self->get_chrom() ne $other->get_chrom();
+	return 0 if $self->get_strand() ne $other->get_strand() && $strand_based eq "same_strand";
+	return 0 if $self->get_strand() eq $other->get_strand() && $strand_based eq "op_strand";
+
+	if (
+		(
+			   $self->get_start() >= ( $other->get_start - $buffer )
+			&& $self->get_start() <= ( $other->get_end() + $buffer )
+		)
+		|| (   $other->get_start() >= ( $self->get_start - $buffer )
+			&& $other->get_start() <= ( $self->get_end() + $buffer ) )
+	  )
+	{
+		return 1;
+	}
+	else {
+		return 0;
+	}
+}
+
+sub add_transcript {
+	my $self = shift;
+	my ( $transcript_name, $transcript_type, $start_coord, $end_coord ) = @_;
+
+	$self->{transcript}->{$transcript_name} =
+	  GFFTranscript::new( $transcript_name, $transcript_type, $start_coord, $end_coord, $self );
+
+	return $self->{transcript}->{$transcript_name};
+}
+
+sub delete_transcript {
+	my $self = shift;
+	my ($id) = @_;
+	undef $self->{transcript}->{$id};
+	delete $self->{transcript}->{$id};
+	
+	$self->adjust_boundaries_transcript_based();
+}
+
+sub get_name {
+	my $self = shift;
+	return $self->{name};
+}
+
+sub set_name {
+	my $self = shift;
+
+	my ($new_name) = @_;
+	$self->{name} = $new_name;
+}
+
+sub get_id {
+	my $self = shift;
+	return $self->{id};
+}
+
+sub set_id {
+	my $self = shift;
+
+	my ($new_id) = @_;
+
+	$self->{id} = $new_id;
+}
+
+sub set_description {
+	my $self = shift;
+	my ($description) = @_;
+	return $self->{description} = $description;
+}
+
+sub get_description {
+	my $self = shift;
+	return $self->{description};
+}
+
+sub get_transcript {
+	my $self = shift;
+	my ($transcript_name) = @_;
+	return $self->{transcript}->{$transcript_name};
+}
+
+sub get_start {
+	my $self = shift;
+	return $self->{start};
+}
+
+sub get_end {
+	my $self = shift;
+	return $self->{end};
+}
+
+sub set_start {
+	my $self = shift;
+	my ($start_coord) = @_;
+	$self->{start} = $start_coord;
+}
+
+sub set_end {
+	my $self = shift;
+	my ($end_coord) = @_;
+	$self->{end} = $end_coord;
+}
+
+sub get_chrom {
+	my $self = shift;
+	return $self->{chrom};
+}
+
+sub set_chrom {
+	my $self = shift;
+	my ($chrom) = @_;
+	$self->{chrom} = $chrom;
+	# TODO
+	#$self->{chrom_index}->{$chrom}->{$gene_id} =
+	#					$gene_temp_feature;
+}
+
+sub get_strand {
+	my $self = shift;
+	return $self->{strand};
+}
+
+sub set_strand {
+	my $self = shift;
+	my ($strand) = @_;
+	$self->{strand} = $strand;
+}
+
+sub get_transcripts_hash {
+	my $self = shift;
+	$self->{transcript};
+}
+
+sub get_transcripts_array {
+	my $self = shift;
+	return values %{ $self->{transcript} };
+}
+
+
+sub adjust_boundaries_transcript_based {
+	my $self = shift;
+
+	$self->set_start( $self->get_transcript_span_start() );
+	$self->set_end( $self->get_transcript_span_end() );
+
+}
+
+sub get_transcript_span_start {
+	my $self              = shift;
+	my $lower_start_value = -1;
+	foreach my $ref_transcript ( values %{ $self->{transcript} } ) {
+		my $transcript_start = $ref_transcript->get_start();
+		$lower_start_value = $transcript_start if ( $transcript_start < $lower_start_value || $lower_start_value == -1 );
+	}
+	return $lower_start_value;
+}
+
+sub get_transcript_span_end {
+	my $self             = shift;
+	my $higher_end_value = 0;
+	foreach my $ref_transcript ( values %{ $self->{transcript} } ) {
+		my $transcript_end = $ref_transcript->get_end();
+		$higher_end_value = $transcript_end if $transcript_end > $higher_end_value;
+	}
+	return $higher_end_value;
+}
+
+sub toGFF {
+	my $self = shift;
+	my $str =
+	    $self->{chrom} . "\t."
+	  . "\tgene\t"
+	  . $self->{start} . "\t"
+	  . $self->{end} . "\t.\t"
+	  . $self->{strand} . "\t.\t" . "ID="
+	  . $self->{id} . ";" . "Name="
+	  . $self->{name} . ";";
+
+	# Additional attributes
+	foreach my $attribName ( keys %{ $self->{attrib} } ) {
+		next if( $attribName eq "Name" );
+		next if( $attribName eq "ID" );
+		$str .= "$attribName=" . $self->{attrib}{$attribName} . ";";
+	}
+	$str =~ s/$/\n/;
+
+	foreach my $ref_transcript ( values %{ $self->{transcript} } ) {
+		$str .= $ref_transcript->toGFF( $self->{chrom}, $self->{id}, $self->{strand} );
+	}
+	return $str;
+}
+
+
+sub toGTF {
+	my $self = shift;
+	my $str;
+	foreach my $ref_transcript ( values %{ $self->{transcript} } ) {
+		$str .= $ref_transcript->toGTF( $self->{chrom}, $self->{id}, $self->{strand} );
+	}
+	return $str;
+}
+
+sub get_num_transcripts {
+	my $self = shift;	
+	return scalar( values %{ $self->{transcript} } );
+}
+
+
+sub set_attribute {
+	my $self = shift;
+	my ( $key, $value ) = @_;
+
+	return $self->{attrib}{$key} = $value;
+}
+
+sub check_attribute {
+	my $self = shift;
+	my ($key) = @_;
+	return defined $self->{attrib}{$key};
+}
+
+sub get_attribute {
+	my $self = shift;
+	my ($key) = @_;
+	if( not defined $self->{attrib}{$key} ){
+		die "Gene attribute $key does not exist for gene " 
+		. $self->get_id() . " on file " . $self->get_filename() . "\n";
+	}
+	return $self->{attrib}{$key};
+}
+
+sub num_exons {
+	my $self = shift;
+
+	my $num_exons = 0;
+	foreach my $ref_transcript ( values %{ $self->{transcript} } ) {
+		$num_exons += $ref_transcript->num_exons();
+	}
+
+	return $num_exons;
+}
+
+return 1;

--- a/scripts/GFFLib/GFFTranscript.pm
+++ b/scripts/GFFLib/GFFTranscript.pm
@@ -1,0 +1,1462 @@
+package GFFTranscript;
+use strict 'vars';
+use strict 'refs';
+
+use Carp;
+
+use GFFExon;
+use GFFUTR;
+use GFFCDS;
+#use Interval;
+
+sub new {
+	my ( $transcript_id, $transcript_type, $start_coord, $end_coord, $parent ) =
+	  @_;
+
+	my $self = {
+		id              => $transcript_id,
+		transcript_type => $transcript_type,
+		start           => $start_coord,
+		end             => $end_coord,
+		parent          => $parent
+	};
+
+	bless $self, GFFTranscript;
+
+	return $self;
+}
+
+sub get_parent {
+	my $self = shift;
+	return $self->{parent};
+}
+
+sub get_transcript_type {
+	my $self = shift;
+	return $self->{transcript_type};
+}
+
+sub set_transcript_type {
+	my $self = shift;
+	my ($new_type) = @_;
+	$self->{transcript_type} = $new_type;
+}
+
+# Generate a string summnaryzing all splice junctions
+# within a certain pair of coordinates
+# Format:
+# <intron1 start>..<intron1 end>-<intron2 start>..<intron2 end>
+sub get_splice_str_within {
+	my $self = shift;
+
+	my ( $rng_start, $rng_end ) = @_;
+
+	my $exon_arr  = $self->{exons};
+	my $num_exons = scalar( @{$exon_arr} );
+
+	return "" if $num_exons == 1;
+
+	my $str = "";
+
+	for ( my $exon_ind = 0 ; $exon_ind < ( $num_exons - 1 ) ; $exon_ind++ ) {
+
+		my $intron_start = $exon_arr->[$exon_ind]->get_end() + 1;
+		my $intron_end   = $exon_arr->[ $exon_ind + 1 ]->get_start() - 1;
+
+		next if $intron_start < $rng_start;
+		last if $intron_end > $rng_end;
+
+		$str .= $intron_start . ".." . $intron_end . "-";
+	}
+
+	$str =~ s/-$//;
+
+	return $str;
+
+}
+
+sub is_intronic {
+	my $self = shift;
+
+	my ($coord) = @_;
+
+	my $exon_arr  = $self->{exons};
+	my $num_exons = scalar( @{$exon_arr} );
+
+	return 0 if $num_exons == 1;
+
+	for ( my $exon_ind = 0 ; $exon_ind < ( $num_exons - 1 ) ; $exon_ind++ ) {
+
+		my $intron_start = $exon_arr->[$exon_ind]->get_end() + 1;
+		my $intron_end   = $exon_arr->[ $exon_ind + 1 ]->get_start() - 1;
+
+		return 1 if ( $coord >= $intron_start && $coord <= $intron_end );
+	}
+
+	return 0;
+}
+
+# Generate a string summnaryzing all splice junctions
+# Format:
+# <intron1 start>..<intron1 end>-<intron2 start>..<intron2 end>
+sub get_splice_str {
+	my $self = shift;
+
+	my $exon_arr  = $self->{exons};
+	my $num_exons = scalar( @{$exon_arr} );
+
+	return "" if $num_exons == 1;
+
+	my $str = "";
+
+	for ( my $exon_ind = 0 ; $exon_ind < ( $num_exons - 1 ) ; $exon_ind++ ) {
+
+		my $intron_start = $exon_arr->[$exon_ind]->get_end() + 1;
+		my $intron_end   = $exon_arr->[ $exon_ind + 1 ]->get_start() - 1;
+
+		$str .= $intron_start . ".." . $intron_end . "-";
+	}
+
+	$str =~ s/-$//;
+
+	return $str;
+
+}
+
+sub attach_UTR {
+	my $self = shift;
+
+	# Attach cds utr to exon
+	foreach my $ref_utr ( @{ $self->{UTR} } ) {
+		foreach my $ref_exon ( @{ $self->{exons} } ) {
+			if (   $ref_exon->get_start() == $ref_utr->get_start()
+				|| $ref_exon->get_end() == $ref_utr->get_end() )
+			{
+				#print "Attaching UTR " . $ref_utr->get_id() . " to exon " . $ref_exon->get_id() . "\n";  
+				$ref_exon->attach_UTR($ref_utr);
+				last;
+			}
+		}
+	}
+}
+
+sub attach_CDS {
+	my $self = shift;
+
+	foreach my $ref_cds ( @{ $self->{CDS} } ) {
+		foreach my $ref_exon ( @{ $self->{exons} } ) {
+			if (   $ref_exon->get_start() <= $ref_cds->get_start()
+				&& $ref_exon->get_end() >= $ref_cds->get_end() )
+			{
+
+				if ( $ref_exon->has_CDS() ) {
+					print STDERR "Error at trying to attach CDS \'"
+					  . $ref_cds->get_id()
+					  . "\' to exon \'"
+					  . $ref_exon->get_id()
+					  . "\'. This exon is already attached to CDS: \'"
+					  . $ref_exon->get_CDS()->get_id() . "\'\n";
+					print STDERR "Possibly a duplicated gene!\n";
+					print STDERR "Continuing processing of file!\n";
+					next;
+				}
+
+				$ref_exon->attach_CDS($ref_cds);
+				last;
+			}
+		}
+	}
+
+}
+
+sub sort_exon_arr {
+	my $self = shift;
+	
+	croak "ERROR: Transcript " . $self->get_id() . " does not have exons!!!" 
+		if scalar( $self->{exons} ) == 0; 
+
+	# Sort based on absolute coordinates
+	@{ $self->{exons} } =
+	  sort { return $a->get_start() <=> $b->get_start() } @{ $self->{exons} };
+
+	# Sort  based on coding strand coordinates
+	if ( $self->get_strand() eq "-" ) {
+		@{ $self->{exons_strand} } = reverse @{ $self->{exons} };
+	}
+	else {
+		$self->{exons_strand} = $self->{exons};
+	}
+
+}
+
+sub sort_UTR_arr {
+	my $self = shift;
+
+	# Sort based on absolute coordinates
+	@{ $self->{UTR} } =
+	  sort { return $a->get_start() <=> $b->get_start() } @{ $self->{UTR} };
+
+	# Sort  based on coding strand coordinates
+	if ( $self->get_strand() eq "-" ) {
+		@{ $self->{UTR_strand} } = reverse @{ $self->{UTR} };
+	}
+	else {
+		$self->{UTR_strand} = $self->{UTR};
+	}
+
+}
+
+sub sort_CDS_arr {
+	my $self = shift;
+
+	# Sort based on absolute coordinates
+	@{ $self->{CDS} } =
+	  sort { return $a->get_start() <=> $b->get_start() } @{ $self->{CDS} };
+
+	# Sort  based on coding strand coordinates
+	if ( $self->get_strand() eq "-" ) {
+		@{ $self->{CDS_strand} } = reverse @{ $self->{CDS} };
+	}
+	else {
+		$self->{CDS_strand} = $self->{CDS};
+	}
+
+}
+
+sub post_processing {
+	my $self = shift;
+	
+	my ($add_missing) = @_;
+		
+	$self->attach_UTR();
+	$self->attach_CDS();
+
+	 
+	if( $add_missing == 1 ){
+		$self->add_missing_exons_from_CDS()	
+	}
+		
+	# If non-coding and it doesn't have an exon, then add one
+	if( $self->num_exons() == 0  && $self->num_CDSs() == 0 && $add_missing == 1  ){
+		$self->add_missing_exons_from_transcript();
+	}
+	
+	#$self->add_UTR_element_based_on_CDS_exon_difference();
+
+
+	# Sort exon, CDS and UTR based on absolute coordinates and strand based coordinates
+	$self->sort_exon_arr();
+	$self->sort_CDS_arr();
+	$self->sort_UTR_arr();
+
+	
+}
+
+
+sub add_missing_exons_from_CDS {
+	my $self = shift;
+
+	foreach my $ref_CDS ( @{ $self->{'CDS'} } ) {
+		if( not $ref_CDS->is_attached() ){
+			
+
+			my $gene_id     = $self->get_parent()->get_id();
+			my $exon_id     = $gene_id . "-E";
+					
+
+			my $ref_exon = $self->add_exon( $exon_id, $ref_CDS->get_start(), $ref_CDS->get_end() );
+			
+			$self->get_parent()->get_file()->add_exon_to_index( $gene_id, $self, $self->get_parent() ); 
+			
+			$ref_exon->attach_CDS($ref_CDS);
+		}
+		
+	}
+}
+
+
+sub add_missing_exons_from_transcript {
+	my $self = shift;
+
+			
+
+			my $gene_id     = $self->get_parent()->get_id();
+			my $exon_id     = $gene_id . "-E";
+					
+
+			my $ref_exon = $self->add_exon( $exon_id, $self->get_start(), $self->get_end() );
+			
+			$self->get_parent()->get_file()->add_exon_to_index( $gene_id, $self, $self->get_parent() ); 
+			
+}
+
+
+#sub add_UTR_element_based_on_CDS_exon_difference {
+#	my $self = shift;
+#	
+#	# Return if its non-coding gene
+#	return if $self->num_CDSs() == 0;
+#		
+#	for my $currExon ( @{$self->get_exon_array()} ){
+#							
+#			my $exon_id = $currExon->get_id();						
+#			# If current exon does not have CDS neither a UTR attached to it
+#			# this indicates a non-coding exon without an UTR attached
+#			# ADD the UTR!
+#			if( not $currExon->has_CDS() && not $currExon->has_UTR()  ){
+#				
+#				my $utr_type;
+#				
+#				my $cds_length_on_left = 
+#				  $self->get_CDS_length_within( $self->get_start(), $currExon->get_start() - 1 );
+#
+#				my $cds_length_on_right = 
+#				  $self->get_CDS_length_within( $currExon->get_end() + 1 $self->get_end() );
+#				  
+#				croak "ERROR: Trying to create an UTR element in the non-coding exon $exon_id\n" . 
+#				      "This exon is non-coding but is flanked both upstream and downstream by coding exons!\n\n" 
+#				if( $cds_length_on_left > 0 || $cds_length_on_rigth > 0 );
+#				
+#				
+#				
+#				if( $cds_length_on_right > 0 && $self->get_strand() eq '+' ||
+#				    $cds_length_on_left > 0 && $self->get_strand() eq '-'
+#				    ){
+#					$utr_type = 'five_prime_utr'
+#				 }else{
+#				 	$utr_type = 'three_prime_utr'
+#				 }
+#				 
+#				
+#				# Check if all exons either upstream or downstream
+#				# do NOT have a CDS. Otherwise issue an error.
+#				if (  == 0 ||
+#				      == 0 )
+#				
+#				# Create an UTR representing the whole exon
+#				
+#			
+#			}
+#			#If exon 5' end different than CDS boundaries
+#			if{				
+#				# Check if all upstream exons do not have CDS
+#				# Otherwise issue an error
+#				
+#				
+#				# Create a UTR from the start of the exon
+#				# to the the start of the CDS - 1
+#				
+#				
+#				
+#			}
+#			#If exon 3' end different than CDS boundaries
+#			if{				
+#				# Check if the differences is due to STOP codon
+#				# disregard if that's the case
+#
+#				# Check if all downstream exons do not have CDS
+#				# Otherwise issue an error
+#				
+#				
+#				# Create a UTR from the start of CDS + 1 to
+#				# the end of the exon
+#				
+#								
+#				
+#			}
+#				 
+#				
+#				 
+#			
+#			my $currCDS = $currExon->get_CDS();
+#			
+#			if( $currCDS->{start} !=  $currExon->{start} || $currCDS->{end} != $currExon->{end} ){
+#				
+#				# Checking if the difference is due to STOP codon
+#				next if( abs( $currCDS->{end} -  $currExon->{end} ) == 3 && $currExon->is_last() && $currGene->get_strand() eq "+" );
+#				next if( abs( $currCDS->{start} -  $currExon->{start} ) == 3 && $currExon->is_first() && $currGene->get_strand() eq "-" );
+#				
+#				print "\tTranscript: " . $currTranscript->get_id() . 
+#				      " Strand: " . $currGene->get_strand() . 
+#				      " " . $currTranscript->get_exon_span_start() . 
+#				      " " . $currTranscript->get_exon_span_end() . "\n";
+#				      
+#				print "\t\tCDS  Start:" . $currCDS->{start} . "\t\tEnd:" . $currCDS->{end} . "\n";
+#				print "\t\tExon  Start:" . $currExon->{start} . "\t\tEnd:" . $currExon->{end} . "\n";
+#				print "\n";
+#				print $currGene->toGFF();
+#				print "\n";
+#				getc();
+#			
+#			}elsif( $currExon
+#				
+#				
+#				
+#				
+#				elsif( $currTranscript->get_exon_span_start() != $currGene->get_start() ||
+#			        $currTranscript->get_exon_span_end()   != $currGene->get_end()      ){
+#			    print "Different>>>\n";
+#			    print $currGene->toGFF();
+#			    getc();
+#			}
+#				
+#		}		 	
+#	
+#	
+#	my $five_prime_exon = 
+#	if( $self->
+#
+#	
+#		if ( $feature eq $UTR5 ) {
+#			my $curr_gene_name =
+#			  $self->get_gene_name_by_transcript_name($parent);
+#
+#			# If it doesn't have a name create one
+#			if ( $id eq "" ) {
+#				$id =
+#				  $parent . "-UTR"
+#				  . ( $self->{genes}->{$curr_gene_name}->get_transcript($parent)
+#					  ->num_UTRs() + 1 );
+#			}
+#			print STDERR
+#			  "UTR5: $id\tTranscript: $parent\tGene: $curr_gene_name\n"
+#			  if $debug;
+#
+#			$temp_feature =
+#			  $self->{genes}->{$curr_gene_name}->get_transcript($parent)
+#			  ->add_5UTR( $id, $start, $end );
+#		}
+#
+#		if ( $feature eq $UTR3 ) {
+#			my $curr_gene_name =
+#			  $self->get_gene_name_by_transcript_name($parent);
+#
+#			# If it doesn't have a name create one
+#			if ( $id eq "" ) {
+#				$id =
+#				  $parent . "-UTR"
+#				  . ( $self->{genes}->{$curr_gene_name}->get_transcript($parent)
+#					  ->num_UTRs() + 1 );
+#			}
+#			print STDERR
+#			  "UTR3: $id\tTranscript: $parent\tGene: $curr_gene_name\n"
+#			  if $debug;
+#
+#			$temp_feature =
+#			  $self->{genes}->{$curr_gene_name}->get_transcript($parent)
+#			  ->add_3UTR( $id, $start, $end );
+#		}
+#
+#		
+#		
+#		
+#
+#	foreach my $ref_CDS ( @{ $self->{'exon'} } ) {
+#					
+#
+#			my $ref_exon = $self->add_exon( $exon_id, $ref_CDS->get_start(), $ref_CDS->get_end() );
+#			
+#			$self->get_parent()->get_file()->add_exon_to_index( $gene_id, $self, $self->get_parent() ); 
+#			
+#			$ref_exon->attach_CDS($ref_CDS);
+#		}
+#		
+#	}
+#}
+
+
+
+
+
+
+sub force_multi_cds {
+	my $self = shift;
+
+	# No reason to modify if a single exon transcript
+	return if $self->num_exons() == 1;
+
+	# No reason to modify if transcript already have multiple CDS, CDS > 1.
+	# Or if non-coding trancript, CDS = 0
+	return if ( $self->num_CDSs() != 1 );
+
+	# No reason to modify if transcript has multple exons and only one CDS,
+	# but this CDS its attached to one of the exons.
+	# Meaning that this transcript has only one coding exon
+	return if ( $self->{CDS}[0]->is_attached() );
+
+	my $exon_array = $self->get_exon_array();
+
+	# Create a copy of the single CDS
+	# and delete it from Transcript
+	my $single_cds = GFFCDS::copy( $self->{CDS}[0] );
+	$self->delete_CDS_NO_UTR_CHANGES( $self->{CDS}[0] );
+
+	my $single_cds_start = $single_cds->get_start();
+	my $single_cds_end   = $single_cds->get_end();
+
+	my $strand = $self->get_strand();
+
+	foreach my $ref_exon ( @{$exon_array} ) {
+		my $exon_start = $ref_exon->get_start();
+		my $exon_end   = $ref_exon->get_end();
+
+		# Skip exon if it doesn't overlap with CDS: non-coding exon
+		next
+		  if ( $exon_end < $single_cds_start
+			|| $exon_start > $single_cds_end );
+
+		my $new_cds_start = $exon_start;
+
+		# Adjust new CDS start to the single CDS START if current exon
+		# is the first coding exon
+		if (   $single_cds_start > $exon_start
+			&& $single_cds_start <= $exon_end )
+		{
+			$new_cds_start = $single_cds_start;
+		}
+
+		my $new_cds_end = $exon_end;
+
+		# Adjust new CDS end to the single CDS END if current exon
+		# is the LAST coding exon
+		if (   $single_cds_end >= $exon_start
+			&& $single_cds_end < $exon_end )
+		{
+			$new_cds_end = $single_cds_end;
+		}
+
+		my $temp_feature =
+		  $self->add_CDS( $single_cds->get_id(), $new_cds_start, $new_cds_end,
+			"." );
+		$temp_feature->cpy_attrib($single_cds)
+
+	}
+
+	$self->attach_CDS();
+	$self->sort_CDS_arr();
+
+}
+
+sub correct_cds_phase {
+	my $self = shift;
+
+	my $cds_sorted_array = $self->get_CDS_array_strand_based();
+
+	my $phase_next_cds = 0;
+	my $first_exon     = 1;
+	foreach my $ref_cds ( @{$cds_sorted_array} ) {
+
+		if ( $ref_cds->get_phase() ne $phase_next_cds ) {
+			print STDERR "Adjusting phase on transcript "
+			  . $self->{id}
+			  . " CDS start: "
+			  . $ref_cds->get_start()
+			  . " CDS end: "
+			  . $ref_cds->get_end()
+			  . " current phase: "
+			  . $ref_cds->get_phase()
+			  . " CORRECT phase: $phase_next_cds\n";
+
+			$ref_cds->set_phase($phase_next_cds);
+		}
+
+		# Length of the last codon encoded by this CDS feature
+		my $length_last_codon = (
+			abs( $ref_cds->get_start() - $ref_cds->get_end() ) + 1 -
+			  $phase_next_cds ) % 3;
+
+		$phase_next_cds = 0;
+		$phase_next_cds = 1 if ( $length_last_codon == 2 );
+		$phase_next_cds = 2 if ( $length_last_codon == 1 );
+
+		$first_exon = 0;
+	}
+
+}
+
+sub get_exon_array {
+	my $self = shift;
+	return $self->{exons};
+}
+
+sub get_UTR_array {
+	my $self = shift;
+	return $self->{UTR};
+}
+
+sub get_5prime_UTR_length {
+	my $self = shift;
+
+	my $length = 0;
+	foreach my $curr_UTR ( @{ $self->{UTR} } ) {
+
+		# type = [five_prime_utr,three_prime_utr]
+
+		$length += $curr_UTR->get_length()
+		  if $curr_UTR->get_type() eq "five_prime_utr";
+	}
+
+	return $length;
+}
+
+sub get_3prime_UTR_length {
+	my $self = shift;
+
+	my $length = 0;
+	foreach my $curr_UTR ( @{ $self->{UTR} } ) {
+
+		# type = [five_prime_utr,three_prime_utr]
+
+		$length += $curr_UTR->get_length()
+		  if $curr_UTR->get_type() eq "three_prime_utr";
+	}
+
+	return $length;
+}
+
+sub get_CDS_array {
+	my $self = shift;
+	return $self->{CDS};
+}
+
+sub get_CDS_length {
+	my $self = shift;
+
+	my $length = 0;
+	foreach my $curr_CDS ( @{ $self->{CDS} } ) {
+		$length += $curr_CDS->get_length();
+	}
+
+	return $length;
+}
+
+#sub get_CDS_length_within {
+#	my $self = shift;
+#
+#	my ( $rng_start, $rng_end ) = @_;
+#
+#	my $CDS_arr  = $self->{exons};
+#	my $num_CDS = scalar( @{$CDS_arr} );
+#
+#	return 0 if $num_CDS == 0;
+#
+#	my $len = 0;
+#	
+#	my $rngInterval = new Interval( $rng_start, $rng_end );
+#
+#	for ( my $CDS_ind = 0 ; $CDS_ind < ( $CDS_exons - 1 ) ; $CDS_ind++ ) {		
+#		my $cdsInterval = new Interval( $CDS_arr->[$CDS_ind]->get_start(), $CDS_arr->[$CDS_ind]->get_end() );
+#		
+#		$len += $cdsInterval->overlap_length( $rngInterval );
+#	}
+#	return $len;
+#}
+
+
+
+sub get_exon_array_strand_based {
+	my $self = shift;
+	return $self->{exons_strand};
+}
+
+sub get_UTR_array_strand_based {
+	my $self = shift;
+	return $self->{UTR_strand};
+}
+
+sub get_CDS_array_strand_based {
+	my $self = shift;
+	return $self->{CDS_strand};
+}
+
+#sub is_identical {
+#	my $self = shift;
+#	my ( $other_transcript ) = @_;
+
+#	for(my $cont_UTR = 0; $cont_UTR <= scalar( @{$self->{'UTR'}} ); $cont_UTR++ ){
+#     		return 0 if not $ref_exon
+#    }
+
+#    foreach my $ref_exon ( @{$self->{exons}} ){
+#      		$ref_exon->toGFF( $chrom, $self->{id}, $strand );
+#    }
+
+#    foreach my $ref_exon ( @{$self->{'CDS'}} ){
+#      		$ref_exon->toGFF( $chrom, $self->{id}, $strand );
+#    }
+#}
+
+sub add_exon {
+	my $self = shift;
+	my ( $exon_id, $start_coord, $end_coord ) = @_;
+	my $temp_exon = GFFExon::new( $exon_id, $start_coord, $end_coord, $self );
+	push( @{ $self->{exons} }, $temp_exon );
+
+	my @temp = sort { $a->get_start() <=> $b->get_start() } @{ $self->{exons} };
+	@{ $self->{exons} } = @temp;
+
+	return $temp_exon;
+}
+
+sub copy_exon {
+	my $self = shift;
+	my ($other) = @_;
+
+	my $temp_exon = GFFExon::copy( $other, $self );
+	push( @{ $self->{exons} }, $temp_exon );
+
+	my @temp = sort { $a->get_start() <=> $b->get_start() } @{ $self->{exons} };
+	@{ $self->{exons} } = @temp;
+
+	return $temp_exon;
+}
+
+sub delete_exon {
+	my $self                 = shift;
+	my ($exon_to_be_deleted) = @_;
+	my $succesfuly_deleted   = 0;
+
+	print STDERR "GFFTranscript::delete_exon ID param:" . $exon_to_be_deleted->get_id() . "\n";
+	print STDERR "GFFTranscript::delete_exon Number of exons in transcript "
+	  . $self->get_id() . ": "
+	  . scalar( @{ $self->{exons} } ) . "\n";
+
+	for ( my $arrInd = 0 ; $arrInd < scalar( @{ $self->{exons} } ) ; $arrInd++ )
+	{
+		if (
+			$exon_to_be_deleted->get_id() eq $self->{exons}->[$arrInd]->get_id()
+		  )
+		{
+
+			print STDERR "GFFTranscript::delete_exon ID found:"
+			  . $self->{exons}->[$arrInd]->get_id() . "\n";
+
+			# Delete upstream UTR if there is one
+			my $tempUTR_UP = $self->{exons}->[$arrInd]->get_UTR("up");
+
+			if ( $tempUTR_UP != 0 ){
+				print STDERR ">>> Deleting from internal array upstream UTR "
+				  . $tempUTR_UP->get_id() . "\n";
+				$self->delete_UTR_from_internal_array($tempUTR_UP)
+			}
+			  
+
+			# Delete downstream UTR if there is one and if it is not the same UTR as "upstream UTR"
+			my $tempUTR_DOWN = $self->{exons}->[$arrInd]->get_UTR("down");
+
+			if ( $tempUTR_DOWN != 0 && $tempUTR_DOWN != $tempUTR_UP ){
+				print STDERR ">>> Deleting from internal array downstream UTR "
+				  . $tempUTR_DOWN->get_id() . "\n";
+				$self->delete_UTR_from_internal_array($tempUTR_DOWN)
+			}
+			
+			# Delete CDS
+			if ( $exon_to_be_deleted->has_CDS() ){
+				my $tempCDS = $exon_to_be_deleted->get_CDS(); 
+				print STDERR ">>> Deleting from internal array CDS "
+				  . $tempCDS->get_id() . "\n";
+				$self->delete_CDS_from_internal_array($tempCDS)
+			}
+			  
+
+			splice @{ $self->{exons} }, $arrInd, 1;
+
+			# Adjust transcript boundaries
+			$self->adjust_boundaries_exon_based();
+
+			# Adjust gene boundaries
+			$self->get_parent()->adjust_boundaries_transcript_based();
+
+			$succesfuly_deleted = 1;
+			last;
+		}
+	}
+
+	die "Unable to delete exon \'"
+	  . $exon_to_be_deleted->get_id()
+	  . "\' from transcript \'"
+	  . $self->get_id()
+	  . "\' ! Exon not found!"
+	  if $succesfuly_deleted == 0;
+
+}
+
+sub adjust_boundaries_exon_based {
+	my $self = shift;
+
+	$self->set_start( $self->get_exon_span_start() );
+	$self->set_end( $self->get_exon_span_end() );
+
+}
+
+sub delete_UTR_from_exon {
+	my $self = shift;
+
+	my ( $exon_with_UTR_to_be_deleted, $up_downstream ) = @_;
+	my $succesfuly_deleted = 0;
+
+	die "Unable to delete UTR from exon \'"
+	  . $exon_with_UTR_to_be_deleted->get_id()
+	  . "\' from transcript \'"
+	  . $self->get_id()
+	  . "\' ! Exon does not have an UTR!"
+	  if not $exon_with_UTR_to_be_deleted->has_UTR();
+
+	for ( my $arrInd = 0 ; $arrInd < scalar( @{ $self->{exons} } ) ; $arrInd++ )
+	{
+		if ( $exon_with_UTR_to_be_deleted->get_id() eq
+			$self->{exons}->[$arrInd]->get_id() )
+		{
+
+			print STDERR "GFFTranscript::delete_UTR_from_exon ID param:"
+			  . $exon_with_UTR_to_be_deleted->get_id() . "\n";
+			print STDERR "GFFTranscript::delete_UTR_from_exon ID found:"
+			  . $self->{exons}->[$arrInd]->get_id() . "\n";
+
+			# Retrieve reference to the UTR that will be deleted
+			my $tempUTR = $self->{exons}->[$arrInd]->get_UTR($up_downstream);
+
+			die "Error. Not able to find a "
+			  . $up_downstream
+			  . "stream UTR on exon \'"
+			  . $self->{exons}->[$arrInd]->get_id() . "\'\n"
+			  if $tempUTR == 0;
+
+			# The concept of UTR in the context of GFF is different
+			# then the biological concept. The UTR is associated to an exon,
+			# Example:
+			# | = coding
+			# : = UTR
+			# - = intron
+            		#
+			# ||||||||||::::----------::::::::::::
+			#           ^^^^ this UTR is considered internal and cannot be removed 
+  
+			die "Error. $up_downstream UTR "
+			  . $self->{exons}->[$arrInd]->get_id() . " is internal. It cannot be removed!!'\n"
+			  if $tempUTR->is_internal();
+			
+			# Delete UTR from Transcript object
+			$self->delete_UTR($tempUTR);
+
+			# Adjust transcript boundaries
+			$self->adjust_boundaries_exon_based();
+
+			# Adjust gene boundaries
+			$self->get_parent()->adjust_boundaries_transcript_based();
+
+			$succesfuly_deleted = 1;
+			last;
+		}
+	}
+
+	die "Unable to delete UTR from exon \'"
+	  . $exon_with_UTR_to_be_deleted->get_id()
+	  . "\' from transcript \'"
+	  . $self->get_id()
+	  . "\' ! Exon not found!"
+	  if $succesfuly_deleted == 0;
+}
+
+sub copy_UTR {
+	my $self = shift;
+	my ($other) = @_;
+
+	my $temp_utr = GFFUTR::copy( $other, $self );
+	push( @{ $self->{'UTR'} }, $temp_utr );
+
+	my @temp = sort { $a->get_start() <=> $b->get_start() } @{ $self->{'UTR'} };
+	@{ $self->{'UTR'} } = @temp;
+
+	return $temp_utr;
+}
+
+sub add_5UTR {
+
+	my $self = shift;
+	my ( $exon_id, $start_coord, $end_coord ) = @_;
+
+	my $temp_5utr =
+	  GFFUTR::new( $exon_id, $start_coord, $end_coord, "five_prime_utr",
+		$self );
+	push( @{ $self->{'UTR'} }, $temp_5utr );
+
+	my @temp = sort { $a->get_start() <=> $b->get_start() } @{ $self->{'UTR'} };
+	@{ $self->{'UTR'} } = @temp;
+
+	return $temp_5utr;
+}
+
+sub delete_UTR {
+	my $self                = shift;
+	my ($UTR_to_be_deleted) = @_;
+	my $succesfuly_deleted  = 0;
+
+	for ( my $arrInd = 0 ; $arrInd < scalar( @{ $self->{UTR} } ) ; $arrInd++ ) {
+		
+		
+		if ( $UTR_to_be_deleted->get_id() eq $self->{UTR}->[$arrInd]->get_id() )
+		{
+
+			my $param = $UTR_to_be_deleted->get_id();
+			my $found = $self->{UTR}->[$arrInd]->get_id();
+			
+			print STDERR "GFFTranscript::delete_UTR ID param:" . $param . "\n";
+			print STDERR "GFFTranscript::delete_UTR ID found:" . $found  . "\n";
+
+			print STDERR "GFFTranscript::delete_UTR num UTRs:" . $self->num_UTRs() . "\n";
+			
+
+			my $parentExon = $self->{UTR}->[$arrInd]->get_parent_exon();
+			$parentExon->delete_UTR( $self->{UTR}->[$arrInd] );
+
+			print STDERR "GFFTranscript::delete_UTR num UTRs:" . $self->num_UTRs() . "\n";
+			
+
+			# Adjust transcript boundaries
+			$self->adjust_boundaries_exon_based();
+
+			# Adjust gene boundaries
+			$self->get_parent()->adjust_boundaries_transcript_based();
+
+			$succesfuly_deleted = 1;
+			last;
+		}
+	}
+
+	die "Unable to delete UTR \'"
+	  . $UTR_to_be_deleted->get_id()
+	  . "\' from transcript \'"
+	  . $self->get_id()
+	  . "\' ! UTR not found!"
+	  if $succesfuly_deleted == 0;
+
+}
+
+# Delete the CDS from the exon but do not make any change
+# in the UTR. !!!!! PRIVATE method !!!!!!
+sub delete_CDS_NO_UTR_CHANGES {
+	my $self                = shift;
+	my ($CDS_to_be_deleted) = @_;
+	my $succesfuly_deleted  = 0;
+
+	for ( my $arrInd = 0 ; $arrInd < scalar( @{ $self->{CDS} } ) ; $arrInd++ ) {
+		my $uu = $CDS_to_be_deleted->get_id();
+		my $oo = $self->{CDS}->[$arrInd]->get_id();
+		if ( $CDS_to_be_deleted->get_id() eq $self->{CDS}->[$arrInd]->get_id() )
+		{
+
+			my $parentExon = $self->{CDS}->[$arrInd]->get_parent_exon();
+
+			# There is a possibility that the parentExon was not defined:
+			# CDS is longer than exon, what prevents attachment of the CDS to
+			# a parentExon. This happens in case of GFF files which the CDS
+			# is a single feature.
+			$parentExon->delete_CDS_NO_UTR_CHANGES( $self->{CDS}->[$arrInd] )
+			  if defined $parentExon;
+
+			splice @{ $self->{CDS} }, $arrInd, 1;
+
+			$succesfuly_deleted = 1;
+			last;
+		}
+	}
+
+	die "Unable to delete CDS \'"
+	  . $CDS_to_be_deleted->get_id()
+	  . "\' from transcript \'"
+	  . $self->get_id()
+	  . "\' ! CDS not found!"
+	  if $succesfuly_deleted == 0;
+
+}
+
+sub delete_UTR_from_internal_array {
+	my $self                = shift;
+	my ($UTR_to_be_deleted) = @_;
+	my $succesfuly_deleted  = 0;
+
+	for ( my $arrInd = 0 ; $arrInd < scalar( @{ $self->{UTR} } ) ; $arrInd++ ) {
+		my $uu = $UTR_to_be_deleted->get_id();
+		my $oo = $self->{UTR}->[$arrInd]->get_id();
+
+		if ( $UTR_to_be_deleted->get_id() eq $self->{UTR}->[$arrInd]->get_id() )
+		{
+
+			splice @{ $self->{UTR} }, $arrInd, 1;
+			$succesfuly_deleted = 1;
+			last;
+		}
+	}
+
+	die "Unable to delete UTR \'"
+	  . $UTR_to_be_deleted->get_id()
+	  . "\' from transcript \'"
+	  . $self->get_id()
+	  . "\' ! UTR not found!"
+	  if $succesfuly_deleted == 0;
+
+}
+
+sub delete_CDS_from_internal_array {
+	my $self                = shift;
+	my ($CDS_to_be_deleted) = @_;
+	my $succesfuly_deleted  = 0;
+
+	for ( my $arrInd = 0 ; $arrInd < scalar( @{ $self->{CDS} } ) ; $arrInd++ ) {
+
+		my $currCDS = $self->{CDS}->[$arrInd];
+		
+		# CDS could have the same ID. The unique identifier of a CDS is then Parent and coordinates
+		if ( $CDS_to_be_deleted->get_parent()->get_id() eq $currCDS->get_parent()->get_id() &&
+		     $CDS_to_be_deleted->get_start() == $currCDS->get_start() &&
+		     $CDS_to_be_deleted->get_end() == $currCDS->get_end() )
+		
+		{
+			splice @{ $self->{CDS} }, $arrInd, 1;
+			$succesfuly_deleted = 1;
+			last;
+		}
+	}
+
+	die "Unable to delete CDS \'"
+	  . $CDS_to_be_deleted->get_id()
+	  . "\' from transcript \'"
+	  . $self->get_id()
+	  . "\' ! CDS not found!"
+	  if $succesfuly_deleted == 0;
+
+}
+
+sub add_3UTR {
+
+	my $self = shift;
+	my ( $exon_id, $start_coord, $end_coord ) = @_;
+
+	my $temp_3utr =
+	  GFFUTR::new( $exon_id, $start_coord, $end_coord, "three_prime_utr",
+		$self );
+
+	push( @{ $self->{'UTR'} }, $temp_3utr );
+
+	my @temp = sort { $a->get_start() <=> $b->get_start() } @{ $self->{'UTR'} };
+	@{ $self->{'UTR'} } = @temp;
+
+	return $temp_3utr;
+}
+
+sub copy_CDS {
+	my $self = shift;
+	my ($other) = @_;
+
+	my $temp_cds = GFFCDS::copy( $other, $self );
+	push( @{ $self->{'CDS'} }, $temp_cds );
+
+	my @temp = sort { $a->get_start() <=> $b->get_start() } @{ $self->{'CDS'} };
+	@{ $self->{'CDS'} } = @temp;
+
+	return $temp_cds;
+}
+
+sub add_CDS {
+
+	my $self = shift;
+	my ( $exon_id, $start_coord, $end_coord, $phase ) = @_;
+
+	my $temp_cds =
+	  GFFCDS::new( $exon_id, $start_coord, $end_coord, $phase, $self );
+	push( @{ $self->{'CDS'} }, $temp_cds );
+
+	my @temp = sort { $a->get_start() <=> $b->get_start() } @{ $self->{'CDS'} };
+	@{ $self->{'CDS'} } = @temp;
+
+	return $temp_cds;
+}
+
+sub get_exon_span_start {
+	my $self = shift;
+	return $self->{exons}[0]->get_start();
+}
+
+sub get_exon_span_end {
+	my $self = shift;
+	return $self->{exons}[ $self->num_exons() - 1 ]->get_end();
+}
+
+sub set_id {
+	my $self = shift;
+
+	my ($new_id) = @_;
+
+	$self->{id} = $new_id;
+}
+
+sub get_id {
+	my $self = shift;
+	return $self->{id};
+}
+
+sub get_start {
+	my $self = shift;
+	return $self->{start};
+}
+
+sub get_end {
+	my $self = shift;
+	return $self->{end};
+}
+
+sub get_length {
+	my $self = shift;
+	return $self->{end} - $self->{start};
+}
+
+sub set_start {
+	my $self = shift;
+	my ($start_coord) = @_;
+	$self->{start} = $start_coord;
+}
+
+sub set_end {
+	my $self = shift;
+	my ($end_coord) = @_;
+	return $self->{end} = $end_coord;
+}
+
+sub num_exons {
+	my $self = shift;
+	if ( defined( $self->{exons} ) ) {
+		return scalar( @{ $self->{exons} } );
+	}
+	else {
+		return 0;
+	}
+}
+
+sub num_CDSs {
+	my $self = shift;
+	if ( defined( $self->{CDS} ) ) {
+		return scalar( @{ $self->{CDS} } );
+	}
+	else {
+		return 0;
+	}
+}
+
+sub num_UTRs {
+	my $self = shift;
+	if ( defined( $self->{UTR} ) ) {
+		return scalar( @{ $self->{UTR} } );
+	}
+	else {
+		return 0;
+	}
+}
+
+sub get_first_CDS_strand_based {
+	my $self = shift;
+	if ( defined( $self->{CDS_strand} ) ) {
+		return $self->{CDS_strand}[0];
+	}
+	else {
+		return 0;
+	}
+}
+
+sub get_last_CDS_strand_based {
+	my $self = shift;
+	if ( defined( $self->{CDS_strand} ) ) {
+		return $self->{CDS_strand}[ scalar( @{ $self->{CDS_strand} } ) - 1 ];
+	}
+	else {
+		return 0;
+	}
+}
+
+
+sub get_first_exon {
+	my $self = shift;
+	if ( defined( $self->{exons} ) ) {
+		return $self->{exons}[0];
+	}
+	else {
+		return 0;
+	}
+}
+
+sub get_first_exon_strand_based {
+	my $self = shift;
+	if ( defined( $self->{exons_strand} ) ) {
+		return $self->{exons_strand}[0];
+	}
+	else {
+		return 0;
+	}
+}
+
+sub get_last_exon {
+	my $self = shift;
+	if ( defined( $self->{exons} ) ) {
+		return $self->{exons}[ scalar( @{ $self->{exons} } ) - 1 ];
+	}
+	else {
+		return 0;
+	}
+}
+
+sub get_last_exon_strand_based {
+	my $self = shift;
+	if ( defined( $self->{exons_strand} ) ) {
+		return $self->{exons_strand}[ scalar( @{ $self->{exons} } ) - 1 ];
+	}
+	else {
+		return 0;
+	}
+}
+
+sub get_first_UTR {
+	my $self = shift;
+	if ( defined( $self->{UTR} ) ) {
+		return ${ $self->{UTR} }[0];
+	}
+	else {
+		return 0;
+	}
+}
+
+sub get_last_UTR {
+	my $self = shift;
+	if ( defined( $self->{UTR} ) ) {
+		return $self->{UTR}[ scalar( @{ $self->{UTR} } ) - 1 ];
+	}
+	else {
+		return 0;
+	}
+}
+
+sub get_exon_by_name {
+	my $self = shift;
+
+	my ($exon_id) = @_;
+
+	return $self->get_exon($exon_id);
+}
+
+#######################
+# Poor implementation
+#
+# Transcript should store exons in a array and also in a hash
+# then the loop will be not necessary
+
+sub get_exon {
+	my $self = shift;
+
+	my ($exon_id) = @_;
+
+	foreach my $ref_exon ( @{ $self->{exons} } ) {
+		return $ref_exon if ( $ref_exon->get_id() eq $exon_id );
+	}
+
+	die "GFFTransript::get_exon_by_name(): There are no exons with id ="
+	  . $exon_id . "\n";
+}
+
+sub get_exon_by_coord {
+	my $self = shift;
+
+	my ($coord) = @_;
+
+	foreach my $ref_exon ( @{ $self->{exons} } ) {
+		return $ref_exon if ( $ref_exon->get_start() <= $coord && $ref_exon->get_end() >= $coord );
+	}
+
+	return 0;
+}
+
+
+sub get_exon_by_start_end_coord {
+	my $self = shift;
+
+	my ($start, $end) = @_;
+
+	foreach my $ref_exon ( @{ $self->{exons} } ) {
+		return $ref_exon if ( $ref_exon->get_start() == $start && $ref_exon->get_end() == $end );
+	}
+
+	return 0;
+}
+
+
+sub get_exon_with_same_start {
+	my $self = shift;
+
+	my ($other_exon_ref) = @_;
+
+	foreach my $ref_exon ( @{ $self->{exons} } ) {
+		return $ref_exon if ( $ref_exon->has_same_start($other_exon_ref) );
+	}
+
+	return 0;
+}
+
+sub get_exon_with_same_end {
+	my $self = shift;
+
+	my ($other_exon_ref) = @_;
+
+	foreach my $ref_exon ( @{ $self->{exons} } ) {
+		return $ref_exon if ( $ref_exon->has_same_end($other_exon_ref) );
+	}
+
+	return 0;
+}
+
+sub get_compatible_exon {
+	my $self = shift;
+
+	my ($other_exon_ref) = @_;
+
+	foreach my $ref_exon ( @{ $self->{exons} } ) {
+		return $ref_exon if ( $ref_exon->is_compatible_to($other_exon_ref) );
+	}
+
+	return 0;
+}
+
+# feature_type = [exon,five_prime_utr,three_prime_utr,CDS]
+sub num_child_features {
+	my $self = shift;
+
+	my ($feature_type) = @_;
+
+	if ( defined( $self->{$feature_type} ) ) {
+		return scalar( @{ $self->{$feature_type} } );
+	}
+	else {
+		return 0;
+	}
+}
+
+sub push {
+	my $self = shift;
+
+	my ( $other, $start, $end ) = @_;
+
+	foreach my $cexon ( @{ $other->{exons} } ) {
+		if ( $cexon->get_start() >= $start && $cexon->get_end() <= $end ) {
+			my $tmp_exon = $self->copy_exon($cexon);
+
+			if ( $cexon->has_UTR() ) {
+
+				# Up
+				my $up_utr = $cexon->get_UTR("up");
+
+				if ( $up_utr != 0 ) {
+					my $tmp_utr = $self->copy_UTR($up_utr);
+					$tmp_exon->attach_UTR($tmp_utr);
+				}
+
+				# Down
+				my $down_utr = $cexon->get_UTR("down");
+
+				if ( $down_utr != 0 ) {
+					my $tmp_utr = $self->copy_UTR($down_utr);
+					$tmp_exon->attach_UTR($tmp_utr);
+				}
+
+			}
+
+			if ( $cexon->has_CDS() ) {
+				my $tmp_cds = $self->copy_CDS( $cexon->get_CDS() );
+				$tmp_exon->attach_CDS($tmp_cds);
+			}
+
+		}
+	}
+	
+	$self->adjust_boundaries_exon_based();
+	$self->get_parent()->adjust_boundaries_transcript_based();
+
+	return;
+}
+
+sub toGFF {
+	my $self = shift;
+
+	my ( $chrom, $parent, $strand ) = @_;
+
+	my $str =
+	    $chrom . "\t.\t"
+	  . $self->{transcript_type} . "\t"
+	  . $self->{start} . "\t"
+	  . $self->{end} . "\t.\t"
+	  . $strand . "\t.\t" . "ID="
+	  . $self->{id} . ";"
+	  . "Parent=$parent;\n";
+
+	foreach my $ref_exon ( @{ $self->{'UTR'} } ) {
+		$str .= $ref_exon->toGFF( $chrom, $self->{id}, $strand );
+	}
+
+	foreach my $ref_exon ( @{ $self->{exons} } ) {
+		$str .= $ref_exon->toGFF( $chrom, $self->{id}, $strand );
+	}
+
+	foreach my $ref_exon ( @{ $self->{'CDS'} } ) {
+		$str .= $ref_exon->toGFF( $chrom, $self->{id}, $strand );
+	}
+
+	return $str;
+}
+
+sub toGTF {
+	my $self = shift;
+
+	my ( $chrom, $parent, $strand ) = @_;
+		
+	my $str;
+	foreach my $ref_exon ( @{ $self->{'UTR'} } ) {
+		#print STDERR "IN UTR\n";
+		#getc();
+		$str .= $ref_exon->toGTF( $chrom, $self->{id}, $strand );
+	}
+
+	foreach my $ref_exon ( @{ $self->{'CDS'} } ) {
+		#print STDERR "IN CDS\n";
+		#getc();
+		$str .= $ref_exon->toGTF( $chrom, $self->{id}, $strand );
+	}
+
+	my $transcript_id = $self->get_id();
+	my $gene_id = $self->get_parent()->get_id();
+	
+	$str =~ s/\n/\tgene_id \"$gene_id\"; transcript_id \"$transcript_id\";\n/g;
+
+	return $str;
+}
+
+
+sub set_attribute {
+	my $self = shift;
+	my ( $key, $value ) = @_;
+
+	return $self->{attrib}{$key} = $value;
+}
+
+sub get_attribute {
+	my $self = shift;
+	my ($key) = @_;
+	return $self->{attrib}{$key};
+}
+
+sub get_strand {
+	my $self = shift;
+	return $self->{parent}->get_strand();
+}
+
+sub get_chrom {
+	my $self = shift;
+	return $self->{parent}->get_chrom();
+}
+
+return 1;

--- a/scripts/GFFLib/GFFUTR.pm
+++ b/scripts/GFFLib/GFFUTR.pm
@@ -1,0 +1,192 @@
+package GFFUTR;
+use strict 'vars';
+use strict 'refs';
+
+require GFFTranscript;
+require GFFExon;
+
+# use overload '==' => \&compare;
+# type = [five_prime_utr,three_prime_utr]	
+sub new {
+	my ( $exon_name, $start_coord, $end_coord, $type, $parent ) = @_;
+	my $self = { id => $exon_name,
+		     	 start => $start_coord,
+		     	 end => $end_coord,
+		     	 type => $type,		     
+		     	 parent => $parent };
+			  
+	bless $self, GFFUTR;
+	
+	return $self;
+}
+
+sub copy {
+	my ( $ref, $parent ) = @_;
+
+
+	my $self = {
+			id     => $ref->{id},
+			start  => $ref->{start},
+			end    => $ref->{end},
+			type   => $ref->{type},
+			parent => $parent
+		};
+
+	bless $self, GFFUTR;
+
+	# Copying other atrributes
+	$self->cpy_attrib($ref);
+	return $self;
+}
+
+sub cpy_attrib{
+	my $self = shift;
+	my ( $ref ) = @_;
+	
+	foreach my $ckey ( keys %{$ref->{attrib}} ){
+		$self->{attrib}{$ckey} = $ref->{attrib}{$ckey}
+	}
+}
+
+			# The concept of UTR in the context of GFF is different
+			# then the biological concept. The UTR is associated to an exon,
+			# Example:
+			# | = coding
+			# : = UTR
+			# - = intron
+            		#
+			# ||||||||||::::----------::::::::::::
+			#           ^^^^ this UTR is considered internal and cannot be removed 
+
+
+sub is_internal {
+    my $self = shift;
+
+    my $transcript = $self->{parent}->get_parent();
+	return 0 if ( $self->get_start() == $transcript->get_start() || $self->get_end() == $transcript->get_end() );
+	return 1;
+}
+
+# type = [five_prime_utr,three_prime_utr]	
+sub get_type {
+	my $self = shift;
+	return $self->{type};
+}
+
+sub get_type_GTF {
+	my $self = shift;
+	return '5UTR' if $self->{type} eq 'five_prime_utr';
+	return '3UTR' if $self->{type} eq 'three_prime_utr';
+}
+
+
+sub get_parent {
+	my $self = shift;
+	return $self->{parent};
+}
+
+sub set_id {
+	my $self = shift;
+	
+	my ($new_id) = @_;
+	
+	$self->{id} = $new_id;
+}
+
+
+sub get_id {
+	my $self = shift;
+	return $self->{id};
+}
+
+
+sub get_start {
+	my $self = shift;
+	return $self->{start};
+}
+	
+sub get_end {
+	my $self = shift;
+	return $self->{end};
+}
+
+sub get_length {
+	my $self = shift;
+	
+	return $self->{end} - $self->{start} + 1;
+}
+	
+
+sub set_start {
+	my $self = shift;
+	my ( $coord_start ) = @_;
+	
+	return $self->{start} = $coord_start;
+}
+	
+sub set_end {
+	my $self = shift;
+	my ( $coord_end ) = @_;
+	
+	return $self->{end} = $coord_end;
+}
+
+sub set_parent_exon{
+	my $self = shift;
+	my ( $ref_exon ) = @_;
+	
+	$self->{exon} = $ref_exon; 
+}
+
+sub get_parent_exon{
+	my $self = shift;
+	return $self->{exon}; 
+}
+
+
+sub toGFF {
+	my $self = shift;
+	
+	my ($chrom, $parent, $strand ) = @_;
+	
+	my $str = $chrom . "\t.\t" . $self->{type} . "\t" . 
+	      $self->{start} . "\t" . 
+	      $self->{end} . "\t.\t" . 
+	      $strand . "\t.\t" . 
+	      "ID=" . $self->{id} . ";" .
+      	      "Parent=$parent;\n";
+      	      
+    return $str;	
+}
+
+sub toGTF {
+	my $self = shift;
+	
+	#print STDERR "UTR\n";
+	#getc();
+	
+	my ($chrom, $parent, $strand ) = @_;
+	
+	my $str = $chrom . "\t.\t" . $self->get_type_GTF() . "\t" . 
+	      $self->{start} . "\t" . 
+	      $self->{end} . "\t.\t" . 
+	      $strand . "\t.\n";
+      	      
+    return $str;	
+}
+
+sub set_attribute {
+	my $self = shift;
+	my ( $key, $value ) = @_;
+	
+	return $self->{attrib}{$key} = $value;
+}
+
+
+sub get_attribute {
+	my $self = shift;
+	my ($key) = @_;
+	return $self->{attrib}{$key};
+}	
+	
+return 1;

--- a/scripts/GFFLib/GFFUtils.pm
+++ b/scripts/GFFLib/GFFUtils.pm
@@ -1,0 +1,486 @@
+package GFFUtils;
+use strict 'vars';
+use strict 'refs';
+
+use GFFGene;
+use GFFExon;
+use GFFUTR;
+use GFFCDS;
+use GFFTranscript;
+
+use Data::Dumper;
+
+#use Set::IntervalTree;
+
+sub are_end_exons_compatible {
+	my ( $gffTrans1, $gffTrans2 ) = @_;
+
+	# End exons are compatible if
+	# - end coordinates of the first exon are the same
+	# - start coordinates of the last exon are the same
+	return 0
+	  if $gffTrans1->get_first_exon()->get_end() !=
+		  $gffTrans2->get_first_exon()->get_end();
+	return 0
+	  if $gffTrans1->get_end_exon()->get_start() !=
+		  $gffTrans2->get_end_exon()->get_start();
+
+	return 1;
+}
+
+sub are_exons_compatible {
+	my ( $gffExon1, $gffExon2 ) = @_;
+
+# Exons are compatible if:
+# - They are the last exons and start coordinates are identical
+# - They are the first exons and end coordinates are identical
+# - If they are neither the first nor the last exons but the coordinates are identical
+
+	return 1
+	  if ( ( $gffExon1->get_start() == $gffExon2->get_start() )
+		&& ( $gffExon1->get_end() == $gffExon2->get_end() ) );
+	return 1
+	  if ( $gffExon1->is_first()
+		&& $gffExon2->is_first()
+		&& ( $gffExon1->get_end() == $gffExon2->get_end() ) );
+	return 1
+	  if ( $gffExon1->is_last()
+		&& $gffExon2->is_last()
+		&& ( $gffExon1->get_start() == $gffExon2->get_start() ) );
+
+	return 0;
+}
+
+sub ref_based_transcript_trimming {
+	my ( $gffTransRef, $gffTransNew, $end ) =
+	  @_;    #$end = [up,down], up = upstream end, down = downstream end
+
+	if ( $end eq "up" ) {
+		$gffTransNew->get_first_exon()
+		  ->set_start( $gffTransRef->get_first_exon()->get_start() );
+		$gffTransNew->get_first_UTR()
+		  ->set_start( $gffTransRef->get_first_UTR()->get_start() );
+		$gffTransNew->set_start( $gffTransRef->get_start() );
+	}
+	elsif ( $end eq "down" ) {
+		my $new_exon_end = $gffTransRef->get_last_exon()->get_end();
+		my $new_UTR_end  = $gffTransRef->get_last_UTR()->get_end();
+		print "\tSetting to $new_exon_end - $new_UTR_end\n";
+		$gffTransNew->get_last_exon()->set_end($new_exon_end);
+		$gffTransNew->get_last_UTR()->set_end($new_UTR_end);
+		$gffTransNew->set_end( $gffTransRef->get_end() );
+	}
+	else {
+		die
+"GFFUtils::ref_based_transcript_trimming third parameter should be either \"up\" or \"down\"\n";
+	}
+
+}
+
+sub ref_based_exon_trimming {
+	my ( $gffExonRef, $gffExonNew, $end ) =
+	  @_;    #$end = [up,down], up = upstream end, down = downstream end
+
+	return ref_based_exon_adjustment( $gffExonRef, $gffExonNew, $end );
+}
+
+sub ref_based_exon_adjustment {
+	my ( $gffExonRef, $gffExonNew, $end ) = @_
+	  ; #$end = [up,down], up = upstream end, down = downstream end, both = both ends will be adjusted (for single exons)
+
+	my $gffTransNew = $gffExonNew->get_parent();
+	my $gffTransRef = $gffExonRef->get_parent();
+
+	if ( $end eq "up" || $end eq "both" ) {
+
+		my $target_start = $gffExonRef->get_start();
+
+		# Exon cannot shrink to a start value higher than the start attached CDS
+		if ( $gffExonNew->has_CDS() ) {
+			my $max_start = $gffExonNew->get_CDS()->get_start();
+			$target_start = $max_start if ( $target_start > $max_start );
+		}
+
+		print ">> $target_start\n";
+		$gffExonNew->set_start($target_start);
+		$gffTransNew->set_start($target_start);
+
+	}
+	if ( $end eq "down" || $end eq "both" ) {
+
+		my $target_end = $gffExonRef->get_end();
+
+		# Exon cannot shrink to an end value lower than the end attached CDS
+		if ( $gffExonNew->has_CDS() ) {
+			my $min_end = $gffExonNew->get_CDS()->get_end();
+			$target_end = $min_end if ( $target_end < $min_end );
+		}
+
+		print ">> $target_end\n";
+		$gffExonNew->set_end($target_end);
+		$gffTransNew->set_end($target_end);
+
+	}
+
+	if ( $end ne "up" && $end ne "down" && $end ne "both" ) {
+		die
+"GFFUtils::ref_based_exon_adjustment third parameter should be either \"up\" or \"down\"\n";
+	}
+
+}
+
+#sub intersection{
+#  my ($gffFILE1, $gffFILE2) = @_;
+#
+#  my $tree = Set::IntervalTree->new;
+#
+#  my $gffGenes1 = $gffFILE1->get_genes_hash();
+#
+#  for my $currGene (values %{$gffGenes1} ){
+#	for my $currTranscript ( values %{$currGene->get_transcripts_hash()} ){
+#		my $min = $currTranscript->get_exon()->get_start();
+#		my $max = $currTranscript->get_exon()->get_end();
+#
+#		$tree->insert( new Number::Interval( Min=> $min, Max => $max ), $min, $max );
+#
+#	}
+#  }
+#
+#  my $gffGenes2 = $gffFILE2->get_genes_hash();
+#
+#  for my $currGene (values %{$gffGenes} ){
+#	for my $currTranscript ( values %{$currGene->get_transcripts_hash()} ){
+#		my $min = $currTranscript->get_exon()->get_start();
+#		my $max = $currTranscript->get_exon()->get_end();
+#
+#		my $ref_current_interval = new Number::Interval( Min=> $min, Max => $max );
+#
+#		# Retrieve intervals that overlap with current interval
+#		my $arr_ref_intervals = $tree->fetch( $min, $max );
+#
+#		# Generate intersection interval
+#		my $arr_ref_intersection_intervals = interval_intersection( $ref_current_interval, $arr_ref_intervals );
+#
+#	}
+#  }
+#
+#}
+
+sub _interval_intersection {
+	my ( $ref_interval, $ref_arr_interval ) = @_;
+
+	foreach my $curr_interval ( @{$ref_arr_interval} ) {
+	}
+}
+
+sub sort_gene_arrays {
+	my ( $gffGeneArrayRef, $numerical_chrom ) = @_;
+
+	# Try to use the numerical part of chrom and then start coord of gene
+
+	if ($numerical_chrom) {
+		@{$gffGeneArrayRef} =
+		  sort {
+
+			my ($a_num_chrom) = ( $a->get_chrom() =~ /(\d+)/ );
+			my ($b_num_chrom) = ( $b->get_chrom() =~ /(\d+)/ );
+
+			return $a_num_chrom <=> $b_num_chrom
+			  || $a->get_start() <=> $b->get_start()
+		  } @{$gffGeneArrayRef};
+	}
+	else {
+		@{$gffGeneArrayRef} =
+		  sort {
+			return $a->get_chrom() cmp $b->get_chrom()
+			  || $a->get_start() <=> $b->get_start()
+		  } @{$gffGeneArrayRef};
+
+	}
+
+}
+
+sub is_gene_different_transcript_span {
+	my ( $gene) = @_;
+
+	if( $gene->get_transcript_span_start()  != $gene->get_start() ){
+		return 1;
+	}
+
+	if( $gene->get_transcript_span_end()  != $gene->get_end() ){
+		return 1;
+	}
+
+	return 0;
+}
+
+sub print_exon_comparison {
+	my ( $gene_a, $gene_b ) = @_;
+
+	my $gffTranscripts_a = $gene_a->get_transcripts_hash();
+	my $gffTranscripts_b = $gene_b->get_transcripts_hash();
+
+	for my $currTranscript_a ( values %{$gffTranscripts_a} ) {
+		for my $currTranscript_b ( values %{$gffTranscripts_b} ) {
+			for my $currExon_a ( @{ $currTranscript_a->get_exon_array() } ) {
+				for my $currExon_b ( @{ $currTranscript_b->get_exon_array() } )
+				{
+
+					my $equivalence_symbol = "";
+					if ( $currExon_a->identical($currExon_b) ) {
+						$equivalence_symbol = "=";
+					}
+					elsif ( $currExon_a->overlaps($currExon_b) ) {
+						$equivalence_symbol = "~";
+					}
+					print "\tEXON:\t"
+					  . $currExon_a->get_id() . ":"
+					  . $currExon_a->get_start() . "-"
+					  . $currExon_a->get_end() . "\t"
+					  . $equivalence_symbol . "\t"
+					  . $currExon_b->get_id() . ":"
+					  . $currExon_b->get_start() . "-"
+					  . $currExon_b->get_end() . "\n"
+					  if $equivalence_symbol ne "";
+				}
+			}
+		}
+	}
+}
+
+sub exon_comparison {
+	my ( $gene_a, $gene_b ) = @_;
+
+	my $content = "";
+	
+	my $gffTranscripts_a = $gene_a->get_transcripts_hash();
+	my $gffTranscripts_b = $gene_b->get_transcripts_hash();
+
+	for my $currTranscript_a ( values %{$gffTranscripts_a} ) {
+		for my $currTranscript_b ( values %{$gffTranscripts_b} ) {
+			for my $currExon_a ( @{ $currTranscript_a->get_exon_array() } ) {
+				my $identical_or_overlaps = 0;
+
+				for my $currExon_b ( @{ $currTranscript_b->get_exon_array() } )
+				{
+					$identical_or_overlaps = 1
+					  if ( $currExon_a->identical($currExon_b)
+						|| $currExon_a->overlaps($currExon_b) );
+				}
+				
+				if ( $identical_or_overlaps == 0 ) {
+					$content .= "\tEXON:\t"
+					  . $currExon_a->get_id() . ":"
+					  . $currExon_a->get_start() . "-"
+					  . $currExon_a->get_end() . "\t" . "ONLY" . "\t" . "\n";
+				}
+			}
+		}
+	}
+
+	for my $currTranscript_b ( values %{$gffTranscripts_b} ) {
+		for my $currTranscript_a ( values %{$gffTranscripts_a} ) {
+			for my $currExon_b ( @{ $currTranscript_b->get_exon_array() } ) {
+				my $identical_or_overlaps = 0;
+				for my $currExon_a ( @{ $currTranscript_a->get_exon_array() } )
+				{
+					$identical_or_overlaps = 1
+					  if ( $currExon_b->identical($currExon_a)
+						|| $currExon_b->overlaps($currExon_a) );
+				}
+				if ( $identical_or_overlaps == 0 ) {
+					$content .= "\tEXON:\t\tONLY\t"
+					  . $currExon_b->get_id() . ":"
+					  . $currExon_b->get_start() . "-"
+					  . $currExon_b->get_end() . "\n";
+				}
+			}
+		}
+	}
+
+	for my $currTranscript_a ( values %{$gffTranscripts_a} ) {
+		for my $currTranscript_b ( values %{$gffTranscripts_b} ) {
+			for my $currExon_a ( @{ $currTranscript_a->get_exon_array() } ) {
+				for my $currExon_b ( @{ $currTranscript_b->get_exon_array() } )
+				{
+
+					if ( not $currExon_a->identical($currExon_b)
+						&& $currExon_a->overlaps($currExon_b) )
+					{
+						$content .= "\tEXON:\t"
+						  . $currExon_a->get_id() . ":"
+						  . $currExon_a->get_start() . "-"
+						  . $currExon_a->get_end() . "\t" . "~" . "\t"
+						  . $currExon_b->get_id() . ":"
+						  . $currExon_b->get_start() . "-"
+						  . $currExon_b->get_end() . "\n";
+					}
+
+				}
+			}
+		}
+	}
+	
+	return $content;
+}
+
+sub overlapping_genes_ {
+	my ( $gff_a, $gff_b ) = @_;
+
+	return overlapping_genes_using_buffer( $gff_a, $gff_b, 0 );
+}
+
+sub overlapping_genes_using_buffer {
+
+	# Reference GFFFile
+	my ( $gff_a, $gff_b, $buffer ) = @_;
+
+	my $gffAGenes = $gff_a->get_genes_hash();
+	my $gffBGenes = $gff_b->get_genes_hash();
+
+	my $gff_filename_a = $gff_a->get_filename();
+	my $gff_filename_b = $gff_b->get_filename();
+
+	# Ordering genes based on template name and start coord
+	my @gffGenesArray = ( values %{$gffAGenes}, values %{$gffBGenes} );
+
+	GFFUtils::sort_gene_arrays( \@gffGenesArray, 0 );
+
+	my %overlap_from_A;
+	my %overlap_from_B;
+
+	for ( my $i1 = 0 ; $i1 < scalar(@gffGenesArray) ; $i1++ ) {
+
+		#print $gffGenesArray[ $i1 ]->toGFF();
+		#getc();
+
+		for ( my $i2 = $i1 + 1 ; $i2 < scalar(@gffGenesArray) ; $i2++ ) {
+			last
+			  if (
+				not $gffGenesArray[$i1]
+				->overlaps( $gffGenesArray[$i2], "strandness", $buffer ) );
+			next
+			  if ( $gffGenesArray[$i1]->get_filename() eq
+				$gffGenesArray[$i2]->get_filename() );
+
+			my $gene_a;
+			my $gene_b;
+
+			if (   $gffGenesArray[$i1]->get_filename() eq $gff_filename_a
+				&& $gffGenesArray[$i2]->get_filename() eq $gff_filename_b )
+			{
+				$gene_a = $gffGenesArray[$i1];
+				$gene_b = $gffGenesArray[$i2];
+
+			}
+			elsif ($gffGenesArray[$i1]->get_filename() eq $gff_filename_b
+				&& $gffGenesArray[$i2]->get_filename() eq $gff_filename_a )
+			{
+				$gene_b = $gffGenesArray[$i1];
+				$gene_a = $gffGenesArray[$i2];
+
+			}
+			else {
+				die "Unknown filenames:\n\t"
+				  . $gffGenesArray[$i1]->get_filename() . "\n\t"
+				  . $gffGenesArray[$i2]->get_filename() . "\n";
+			}
+
+			#			print STDERR "GENE:\t"
+			#			  . $gene_a->get_id() . ":"
+			#			  . $gene_a->get_chrom() . ":"
+			#			  . $gene_a->get_start() . "-"
+			#			  . $gene_a->get_end() . ":"
+			#			  . $gene_a->get_strand()
+			#			  . ":exons="
+			#			  . $gene_a->num_exons() . "\t"
+			#			  . $gene_b->get_id() . ":"
+			#			  . $gene_b->get_chrom() . ":"
+			#			  . $gene_b->get_start() . "-"
+			#			  . $gene_b->get_end() . ":"
+			#			  . $gene_a->get_strand()
+			#			  . ":exons="
+			#			  . $gene_b->num_exons() . "\n";
+
+			my $a_id = $gene_a->get_id();
+			my $b_id = $gene_b->get_id();
+
+			$overlap_from_A{$a_id} = $b_id;
+			$overlap_from_B{$b_id} = $a_id;
+		}
+
+	}
+
+	return ( \%overlap_from_A, \%overlap_from_B );
+}
+
+# List issues like this
+
+# Current model                                       |||||-----||||||||----------||||||
+# Final model                                         |||||-----||||||||||||||||||||||||
+
+# OR
+
+# Current model                                       |||||-----||||||||----------||||||
+# Final model                                         |||||-----|||||||||||||||||||||
+
+sub was_an_intron_retained {
+
+	my ( $transA, $transB ) = @_;
+
+	# Format:
+	# <intron1 start>..<intron1 end>-<intron2 start>..<intron2 end>
+	my $splice_str = $transB->get_splice_str();
+
+	my @splices = split "-", $splice_str;
+
+	foreach my $curr_splice (@splices) {
+		my ( $splice_start, $splice_end ) =
+		  ( $curr_splice =~ /(\d+)\.\.(\d+)/ );
+
+		my $exon_A_overlaping_start = $transA->get_exon_by_coord($splice_start);
+		my $exon_A_overlaping_end   = $transA->get_exon_by_coord($splice_end);
+
+#print "$exon_A_overlaping_start $exon_A_overlaping_end\n" if ( $transcript_id eq 'AN7351_mRNA' );
+
+		# If one of the attempts of retrieving the gene fails THEN
+		# coord. still belongs to an intron. NO INTEGRAL intron retention
+		next
+		  if ( $exon_A_overlaping_start == 0 || $exon_A_overlaping_end == 0 );
+
+		# If the same exon was retrieved using the $splice_start and $splice_end
+		# THEN INTEGRAL RETENTION happened
+		if ( $exon_A_overlaping_start->get_start() ==
+			   $exon_A_overlaping_end->get_start()
+			&& $exon_A_overlaping_start->get_end() ==
+			$exon_A_overlaping_end->get_end() )
+		{
+			return 1;
+
+		}
+	}
+	return 0;
+}
+
+# List issues like this
+
+# Current model                                       |||||-----||||||||----------||||||
+# Transcript evidence with partial intron retention   |||||-----|||||||||||
+# Final model                                         |||||-----|||||||||||
+
+sub was_an_intron_partially_retained {
+
+	my ( $transA, $transB ) = @_;
+
+# if none of the ends of current model is intronic when compared to previous version then
+# this is not the case that we are looking for.
+	if (   $transB->is_intronic( $transA->get_start() )
+		|| $transB->is_intronic( $transA->get_end() ) )
+	{
+		return 1;
+	}
+	return 0;
+}
+
+return 1;
+

--- a/scripts/GFFLib/gff_compare.pl
+++ b/scripts/GFFLib/gff_compare.pl
@@ -1,0 +1,146 @@
+#!/usr/bin/perl
+use strict;
+
+use FindBin;
+use lib $FindBin::Bin;
+
+use GFFFile;
+use GFFUtils;
+
+my $usage = "gff_compare.pl <GFF A> <GFF B>\n\n";
+
+die $usage if scalar(@ARGV) != 2;
+
+my $gff_filename_a = $ARGV[0];
+my $gff_filename_b = $ARGV[1];
+
+my $gff_a = GFFFile::new($gff_filename_a);
+$gff_a->read();
+
+my $gff_b = GFFFile::new($gff_filename_b);
+$gff_b->read();
+
+my $gffAGenes = $gff_a->get_genes_hash();
+my $gffBGenes = $gff_b->get_genes_hash();
+
+# Ordering genes based on template name and start coord
+my @gffGenesArray = ( values %{$gffAGenes}, values %{$gffBGenes} );
+
+GFFUtils::sort_gene_arrays( \@gffGenesArray, 0 );
+
+# This hash prevent a second comparison of genes that have identical
+# counterpart in the other file
+my %identicals;
+
+# This check will keep track of genes that at least overlaps with other
+# genes. Later it will be used to report genes that are only found
+# in each of the files
+my %similars;
+
+for ( my $i1 = 0 ; $i1 < scalar(@gffGenesArray) ; $i1++ ) {
+
+	#print $gffGenesArray[ $i1 ]->toGFF();
+	#getc();
+
+	next if defined $identicals{ $gffGenesArray[$i1]->get_id() };
+
+	for ( my $i2 = $i1 + 1 ; $i2 < scalar(@gffGenesArray) ; $i2++ ) {
+		last if ( not $gffGenesArray[$i1]->overlaps( $gffGenesArray[$i2] ) );
+		next
+		  if ( $gffGenesArray[$i1]->get_filename() eq
+			$gffGenesArray[$i2]->get_filename() );
+		next if defined $identicals{ $gffGenesArray[$i2]->get_id() };
+
+		my $gene_a;
+		my $gene_b;
+
+		if (   $gffGenesArray[$i1]->get_filename() eq $gff_filename_a
+			&& $gffGenesArray[$i2]->get_filename() eq $gff_filename_b )
+		{
+			$gene_a = $gffGenesArray[$i1];
+			$gene_b = $gffGenesArray[$i2];
+
+		}
+		elsif ($gffGenesArray[$i1]->get_filename() eq $gff_filename_b
+			&& $gffGenesArray[$i2]->get_filename() eq $gff_filename_a )
+		{
+			$gene_b = $gffGenesArray[$i1];
+			$gene_a = $gffGenesArray[$i2];
+
+		}
+		else {
+			die "Unknown filenames:\n\t"
+			  . $gffGenesArray[$i1]->get_filename() . "\n\t"
+			  . $gffGenesArray[$i2]->get_filename() . "\n";
+		}
+
+		my $exon_comparison = GFFUtils::exon_comparison( $gene_a, $gene_b );
+
+		if ( $exon_comparison ne '' ) {
+			print "GENE:\t"
+			  . $gene_a->get_id() . ":"
+			  . $gene_a->get_chrom() . ":"
+			  . $gene_a->get_start() . "-"
+			  . $gene_a->get_end() . ":"
+			  . $gene_a->get_strand()
+			  . ":exons="
+			  . $gene_a->num_exons() . "\t"
+			  . $gene_b->get_id() . ":"
+			  . $gene_b->get_chrom() . ":"
+			  . $gene_b->get_start() . "-"
+			  . $gene_b->get_end() . ":"
+			  . $gene_a->get_strand()
+			  . ":exons="
+			  . $gene_b->num_exons() . "\n";
+			print $exon_comparison;
+			#print "SIM\t" . $gene_a->get_id() . "\n";
+			#print "SIM\t" . $gene_b->get_id() . "\n";
+			$similars{ $gene_a->get_id() } = 1;
+			$similars{ $gene_b->get_id() } = 1;
+		}
+		else {
+			#print "ID\t" . $gene_a->get_id() . "\n";
+			#print "ID\t" . $gene_b->get_id() . "\n";
+			$identicals{ $gene_a->get_id() } = 1;
+			$identicals{ $gene_b->get_id() } = 1;
+			last;
+		}
+
+	}
+
+}
+
+# Report genes only found in one of the GFFs
+
+for ( my $i1 = 0 ; $i1 < scalar(@gffGenesArray) ; $i1++ ) {
+
+	my $gene    = $gffGenesArray[$i1];
+	my $gene_id = $gene->get_id();
+
+	if (   ( not defined( $identicals{$gene_id} ) )
+		and ( not defined( $similars{$gene_id}   ) )
+	   )
+	{
+		#print "ONLY\t" . $gene_id . "\n";
+		
+		my $content =
+		    $gene->get_id() . ":"
+		  . $gene->get_chrom() . ":"
+		  . $gene->get_start() . "-"
+		  . $gene->get_end() . ":"
+		  . $gene->get_strand()
+		  . ":exons="
+		  . $gene->num_exons();
+
+		if ( $gene->get_filename() eq $gff_filename_a ) {
+			print "GENE:\t" . $content . "\t" . "ONLY\n";
+		}
+		elsif ( $gene->get_filename() eq $gff_filename_b ) {
+			print "GENE:\t" . "ONLY" . "\t" . $content . "\n";
+		}
+		else {
+			die "Unknown filename:\n\t" . $gene->get_filename() . "\n";
+		}
+	}
+
+}

--- a/scripts/GFFLib/gff_distrib_intron_length.pl
+++ b/scripts/GFFLib/gff_distrib_intron_length.pl
@@ -1,0 +1,123 @@
+#!/bin/env perl
+use strict;
+
+use FindBin;
+use lib $FindBin::Bin;
+
+use GFFFile;
+use GFFUtils;
+use Bio::SeqIO;
+use Bio::Seq;
+
+my $usage = "\nusage: $0  <GFF file> ";
+
+my $debug = 0;
+
+die $usage if ( scalar(@ARGV) != 1 );
+
+my $gff_filename = $ARGV[0];
+
+my $gffFile = GFFFile::new($gff_filename);
+
+print "Reading GFF file...\n";
+$gffFile->read( 1, 1 );
+
+my $gffGenes = $gffFile->get_genes_hash();
+
+# Ordering genes based on template name and start coord
+my @gffGenesArray = values %{$gffGenes};
+GFFUtils::sort_gene_arrays( \@gffGenesArray, 0 );
+
+print "Number of genes in the GFF file: " . scalar(@gffGenesArray) . "\n";
+
+my $cont_introns = 0;
+
+my @introns_length;
+
+for my $currGene (@gffGenesArray) {
+	my $gene_id = $currGene->get_id();
+	my $chrom   = $currGene->get_chrom();
+	my $strand  = $currGene->get_strand();
+
+	my $gffTranscripts = $currGene->get_transcripts_hash();
+	for my $currTranscript ( values %{$gffTranscripts} ) {
+		my $transcript_id = $currTranscript->get_id();
+
+		my $intron_str = $currTranscript->get_splice_str();
+
+		next if $intron_str eq "";
+
+		my @introns = split "-", $intron_str;
+
+		my $num_introns_gene = scalar(@introns);
+
+		if ($debug) {
+			print "Intron str: $intron_str Number of introns: "
+			  . $num_introns_gene . "\n";
+			getc();
+		}
+
+		for ( my $i = 0 ; $i < $num_introns_gene ; $i++ ) {
+			my $currIntron = @introns[$i];
+
+			my ( $start, $end ) = ( $currIntron =~ /(\d+)\.\.(\d+)/ );
+
+			my $length = $end - $start + 1;
+
+			push @introns_length, $length;
+			if ($debug) {
+				print
+				  "$gene_id $transcript_id $cont_introns i= $i $start-$end\n";
+				getc();
+			}
+
+			# Writing to files
+			$cont_introns++;
+		}
+
+	}
+}
+
+# Calculate distribution
+
+my @sorted_introns = sort { $a <=> $b } @introns_length;
+
+my $ten_perc          = int( $cont_introns / 100 * 10 );
+my $twenty_five_perc  = int( $cont_introns / 100 * 25 );
+my $fifty_perc        = int( $cont_introns / 100 * 50 );
+my $seventy_five_perc = int( $cont_introns / 100 * 75 );
+my $ninety_perc       = int( $cont_introns / 100 * 90 );
+
+my $num_sorted_introns = scalar(@sorted_introns);
+if ($debug) {
+	print "10% index:  $ten_perc  \n";
+	print "25% index:  $twenty_five_perc  \n";
+	print "50% index:  $fifty_perc  \n";
+	print "75% index:  $seventy_five_perc \n";
+	print "90% index:  $ninety_perc \n";
+
+	print "Number of items: $num_sorted_introns\n";
+}
+
+print "Min:\t" . $sorted_introns[0] . "\n";
+print "10%:\t" . $sorted_introns[$ten_perc] . "\n";
+print "25%(Q1):\t" . $sorted_introns[$twenty_five_perc] . "\n";
+print "50%:\t" . $sorted_introns[$fifty_perc] . "\n";
+print "75%(Q3):\t" . $sorted_introns[$seventy_five_perc] . "\n";
+print "90%:\t" . $sorted_introns[$ninety_perc] . "\n";
+print "Max:\t" . $sorted_introns[ $num_sorted_introns - 1 ] . "\n";
+
+my $q1 =  $sorted_introns[$twenty_five_perc];
+my $q3 =  $sorted_introns[$seventy_five_perc];
+
+
+# Lower bound: Q1 - 1.5 (Q1 - Q3)
+my $outliers_lower_bound = $q1 - ( 1.5 * (  $q3 -  $q1 ) );
+
+# Higher bound: Q3 + 1.5 (Q1 - Q3)
+my $outliers_higher_bound = $q3 + ( 1.5 * (  $q3 -  $q1 ) );
+
+$outliers_lower_bound = 0 if $outliers_lower_bound < 0; 
+
+print "Lower bound:\t" . $outliers_lower_bound  . "\n";
+print "Higher bound:\t" . $outliers_higher_bound  . "\n";

--- a/scripts/GFFLib/gff_dump_introns_GFF_output.pl
+++ b/scripts/GFFLib/gff_dump_introns_GFF_output.pl
@@ -1,0 +1,76 @@
+#!/bin/env perl
+use strict;
+
+use FindBin;
+use lib "$FindBin::Bin";
+
+use GFFFile;
+use GFFUtils;
+use Bio::SeqIO;
+use Bio::Seq;
+
+my $usage =
+"\nusage: $0  <GFF file> <min. intron length> <out intron FASTA>";
+
+
+die $usage if ( scalar(@ARGV) != 3 );
+
+my $gff_filename               = $ARGV[0];
+my $min_intron_length          = $ARGV[1];
+my $out_intron                 = $ARGV[2];
+
+my $gffFile = GFFFile::new($gff_filename);
+
+print "Reading GFF file...\n";
+$gffFile->read( 1, 1 );
+
+
+my $gffGenes = $gffFile->get_genes_hash();
+
+# Ordering genes based on template name and start coord
+my @gffGenesArray = values %{$gffGenes};
+GFFUtils::sort_gene_arrays( \@gffGenesArray, 0 );
+
+print "Number of genes in the GFF file: " . scalar(@gffGenesArray) . "\n";
+
+open OUT_INTRON, ">$out_intron" or die "Unable to open file $out_intron to write\n";
+
+my $cont_introns   = 0;
+
+for my $currGene (@gffGenesArray) {
+	my $gene_id = $currGene->get_id();
+	my $chrom   = $currGene->get_chrom();
+	my $strand  = $currGene->get_strand();
+	
+	
+	my $gffTranscripts = $currGene->get_transcripts_hash();
+	for my $currTranscript ( values %{$gffTranscripts} ) {
+		my $transcript_id  = $currTranscript->get_id();
+		
+		
+		my $intron_str =  $currTranscript->get_splice_str();
+		
+		next if $intron_str eq "";
+		
+		my @introns = split "-", $intron_str;
+		
+		foreach my $currIntron ( @introns ){
+			my ($start, $end) = ( $currIntron =~ /(\d+)\.\.(\d+)/ );
+			
+			my $length = $end - $start + 1;
+			
+			if( $length > $min_intron_length ){
+				
+								
+				# Writing to files
+				print OUT_INTRON "$chrom\tvoid\tintron\t$start\t$end\t.\t$strand\t.\tParent=$transcript_id\n";
+				$cont_introns++;
+			}
+		}
+		
+	}
+}
+
+close(OUT_INTRON);
+print "Number of intron sequences: $cont_introns\n";
+

--- a/scripts/GFFLib/gff_gene_cluster_based_on_genomic_location.pl
+++ b/scripts/GFFLib/gff_gene_cluster_based_on_genomic_location.pl
@@ -1,0 +1,144 @@
+#!/bin/env perl
+use strict;
+
+
+use FindBin;
+use lib $FindBin::Bin;
+
+
+use GFFFile;
+use GFFUtils;
+
+
+
+my $debug = 0;
+
+# Define cluster of genes based on their location in the genome (gene locus).
+# Genes that overlap are considered members of the same cluster
+# The gene with the longest CDS is chosen as the representative of the cluster
+# All representatives are reported in the GFF OUT file
+
+
+my $usage = "$0 <GFF IN> <GFF OUT with one representative for each cluster > \n\n";
+
+die $usage if scalar(@ARGV) != 2;
+
+my $gff_filename_in = $ARGV[0];
+my $out_gff         = $ARGV[1];
+
+my $gff_handler = GFFFile::new( $gff_filename_in );
+$gff_handler->read();
+
+
+my $gffGenes = $gff_handler->get_genes_hash();
+
+# Ordering genes based on template name and start coord
+my @gffGenesArray = values %{$gffGenes};
+GFFUtils::sort_gene_arrays( \@gffGenesArray, 0 );
+
+
+# As genes get added to the cluster the program adjust those variables
+# They represent left and right end of the range spanning all genes in
+# the clusters
+
+my $cluster_start = -1;
+my $cluster_end   = -1;
+
+my $last_gene_chrom;
+
+my @cluster;
+
+open OUT, ">$out_gff" or die "Unable to open file $out_gff to write\n";
+
+for my $currGene (@gffGenesArray) {
+	my $gene_id        = $currGene->get_id();
+	my $gffTranscripts = $currGene->get_transcripts_hash();
+	my $start =  $currGene->get_start();
+	my $end   =  $currGene->get_end();
+	my $chrom =  $currGene->get_chrom();
+	
+	
+	print STDERR "$gene_id...\n" if $debug;
+	
+	if( $start > $end ){
+		my $temp = $start;
+		$start = $end;
+		$end = $temp;
+	}
+	
+	
+	# Start new clusters if no intersection
+	# or if chromosome have changed
+	if ( $start > $cluster_end || $chrom ne $last_gene_chrom ){
+				
+		# If previous cluster not empty, choose the representative
+		# gene and dump it
+		if( scalar ( @cluster ) != 0 ){
+			my $chosen_gene = choose_representative( \@cluster );
+			print OUT $chosen_gene->toGFF();
+			undef @cluster;
+			$cluster_start = -1;
+			$cluster_end   = -1;
+			
+		}		   	   		   
+		$cluster_start = $start;
+		
+	}
+
+	# Extend end of the cluster if needed
+	$cluster_end   = $end if $end > $cluster_end;
+	push @cluster, $currGene;
+	
+	
+	$last_gene_chrom = $chrom;
+
+}
+my $chosen_gene = choose_representative( \@cluster );
+print OUT $chosen_gene->toGFF();
+
+
+close(OUT);
+
+
+
+exit(0);
+
+
+sub choose_representative{
+	my ($clusterRef) = @_;
+	
+	my $chosen;
+	my $longest_cds = 0;
+	
+	foreach my $currGene ( @{$clusterRef} ){
+		my $id = $currGene->get_id();
+
+		my $cds_length = 0;
+
+		my $gffTranscripts = $currGene->get_transcripts_hash();
+		
+		
+		for my $currTranscript ( values %{$gffTranscripts} ) {		
+			my $temp_cds_length = $currTranscript->get_CDS_length();
+			$cds_length = $temp_cds_length if $temp_cds_length > $cds_length;
+		}
+		
+		print STDERR "ID: $id  CDS_LENGTH: $cds_length\n";
+		
+		if( $cds_length > $longest_cds ){
+			$chosen = $currGene;
+			$longest_cds = $cds_length;
+		}
+			
+		
+	}
+	my $chosen_id = $chosen->get_id();
+	print STDERR "CHOSEN ID: $chosen_id\n";
+	print STDERR "======================\n";
+	
+	return $chosen;
+}
+
+
+
+

--- a/scripts/GFFLib/gff_geneid_based_filtering.pl
+++ b/scripts/GFFLib/gff_geneid_based_filtering.pl
@@ -1,0 +1,70 @@
+#!/bin/env perl
+use strict;
+
+use FindBin;
+use lib "$FindBin::Bin";
+
+use GFFFile;
+
+my $usage = "gff_geneid_based_filtering.pl <id list file> <GFF file> <GFF out> [remove]\n\n";
+
+die $usage if ( scalar( @ARGV ) != 3 && scalar( @ARGV ) != 4 );
+
+my $idFile = $ARGV[0];
+my $outFile = $ARGV[2];
+
+# Indicate if the gene list should be either kept or removed from the GFF file 
+my $remove = 0;
+$remove = 1 if( defined( $ARGV[3] ) );
+
+# Genes list
+my %gene_list;
+
+my $num_genes_list = 0;
+my %found;
+
+# Read file listing genes
+open IN, $idFile or die "Unable to open file $idFile\n"; 
+while( <IN> ){
+	my $line = $_;
+	chomp $line;
+	$gene_list{ $line } = 1;
+	$num_genes_list++;
+	$found{ $line } = -1;
+}
+close(IN);
+
+# Reading GFF file	
+my $gffFile = GFFFile::new( $ARGV[1] );
+$gffFile->read();
+
+my $gffGenes = $gffFile->get_genes_hash();
+
+
+
+open OUT, ">$outFile" or die "Unable to open file $outFile\n"; 
+my $num_genes_found = 0;
+# Printing only genes that should be kept
+for my $currGene (values %{$gffGenes} ){
+	my $gene_id = $currGene->get_id();
+	if ( $gene_list{ $gene_id } == 1 ){
+		$found{$gene_id} =  1;
+		$num_genes_found++;	
+	}
+	if( $remove ){
+ 		print OUT $currGene->toGFF()  if ( not defined( $gene_list{ $gene_id } ) );		
+	}else{
+ 		print OUT $currGene->toGFF()  if $gene_list{ $gene_id } == 1;
+	} 	
+}
+
+foreach my $curr_found ( keys %found ){
+	print "NOT FOUND: $curr_found\n" if ( $found{$curr_found} ==  -1 );	
+}
+close(OUT);
+
+print "Number of genes in the list: $num_genes_list\n";
+print "Number of genes found: $num_genes_found\n";
+
+	
+

--- a/scripts/GFFLib/gff_list_alt_splicing_based_on_intron_retention.pl
+++ b/scripts/GFFLib/gff_list_alt_splicing_based_on_intron_retention.pl
@@ -1,0 +1,72 @@
+#!/bin/env perl
+use strict;
+
+use FindBin;
+use lib "$FindBin::Bin";
+
+use GFFFile;
+use GFFUtils;
+
+# List issues like this
+
+# Current model                                       |||||-----||||||||----------||||||
+# Final model                                         |||||-----||||||||||||||||||||||||
+
+# OR
+
+# Current model                                       |||||-----||||||||----------||||||
+# Final model                                         |||||-----|||||||||||||||||||||
+
+
+
+# OR partial intron retentions
+
+
+# Current model                                       |||||-----||||||||----------||||||
+# Transcript evidence with partial intron retention   |||||-----|||||||||||
+# Final model                                         |||||-----|||||||||||
+
+
+my $usage =
+"$0 <GFF file> <log file>\n";
+
+die $usage if scalar(@ARGV) != 2;
+
+my $gffFile = $ARGV[0];
+my $log_file   = $ARGV[1];
+
+print STDERR "Reading $gffFile ...\n";
+my $gff_a = GFFFile::new($gffFile);
+$gff_a->read();
+
+my $gffAGenes = $gff_a->get_genes_hash();
+
+open LOGFILE, ">$log_file" or die "Unable to open logfile $log_file\n";
+print STDERR "Checking alt. splicing ...\n";
+for my $gene_id ( keys %{$gffAGenes} ) {
+
+	my $gffTranscriptsA = $gffAGenes->{$gene_id}->get_transcripts_hash();
+		
+	my $mainTranscript;
+	map {$mainTranscript =  $gffTranscriptsA->{ $_ } if $_ =~ /.1$/ } keys %{$gffTranscriptsA};
+	
+	for my $transcript_id ( keys %{$gffTranscriptsA} ) {
+		next if $transcript_id eq $mainTranscript->get_id();
+		
+		my $altSplicing = $gffTranscriptsA->{$transcript_id};
+		
+		if( GFFUtils::was_an_intron_partially_retained( $altSplicing, $mainTranscript  ) ){
+				print LOGFILE $altSplicing->get_id() . "\n";
+				print OUT $altSplicing->get_id() . "\n";
+				next;			
+		}
+		
+		if( GFFUtils::was_an_intron_retained( $altSplicing, $mainTranscript  ) ){
+				print LOGFILE $altSplicing->get_id() . "\n";
+				print OUT $altSplicing->get_id() . "\n";
+				next;			
+		}		
+	}
+}
+
+close(LOGFILE);

--- a/scripts/GFFLib/gff_rewrite.pl
+++ b/scripts/GFFLib/gff_rewrite.pl
@@ -1,0 +1,176 @@
+#!/usr/bin/env perl
+
+# TODO:
+# * Keep the comments in the beginning of the file (DONE)
+# * Disregard FASTA sequences in the end of the file (DONE)
+# * Implement getOpts (DONE)
+# * Check if this functionality is working: --trim_genes_based_on_transcripts
+# * Propagate Name attribute to gene record (from CDS record) (POSTPONED)
+# * Leave unchanged the second column. (POSTPONED)
+# * If keep_id, and missing mRNA or gene: propagate the ID to all other records. Double check if ID was not used (POSTPONED)
+
+use strict;
+use GFFFile;
+use GFFUtils;
+use Carp;
+use Pod::Usage;
+use Getopt::Long;
+
+$Carp::Verbose = 1;
+
+=head1 NAME
+
+gff_rewrite.pl
+
+=head1 SYNOPSIS
+
+gff_rewrite.pl 
+	--input <GFF IN> 
+	--output <GFF OUT> 
+	[  --change_id_single_exon_id | 
+		--change_id_multi_exon_id ] 
+	[ --discard_non_essential_attributes ]
+	[ --add_missing_features ]		
+
+=head1 OPTIONS
+
+B<--input> - GFF input
+
+B<--output> - GFF output
+
+B<--change_id_single_exon_id> - B<(Optional)> Indicates that IDs should be normalized according to the following rules: 
+	transcript id = <gene_id>-T;
+	CDS id = <gene_id>-P;
+	Exon id = <gene_id>-E;
+	UTR id = <gene_id>-UTR
+	
+B<--change_id_multi_exon_id> - B<(Optional)> Same as change_id_single_exon_id, but in this case the exon IDs will 
+be numbered (e.g. <gene_id>-E1, <gene_id>-E2)
+
+B<--discard_non_essential_attributes> - B<(Optional)> Maintain only the fields Parent, ID and Name on column 9 
+
+B<--add_missing_features> -  B<(Optional)> Add missing exons based on corresponding CDS, missing genes from 
+transcript, missing transcripts from exons and missing exons from transcripts (only non-coding features)
+
+B<--help> - prints the usage information. B<(Optional)>
+
+=head1 DESCRIPTION
+
+
+=head1 CONTACT
+ Gustavo C. Cerqueira (2018)
+ cerca11@gmail.com
+ gcerqueira@pgdx.com
+=cut
+
+my ($in_gff, $out_gff, $change_id_single_exon_id, $change_id_multi_exon_id );
+my ($discard_non_essential_attributes, $add_missing_features);
+my $help;
+
+GetOptions(	'input=s'							=> \$in_gff,
+			'output=s'							=> \$out_gff,
+			'change_id_single_exon_id'			=> \$change_id_single_exon_id,
+			'change_id_multi_exon_id'			=> \$change_id_multi_exon_id,
+			'discard_non_essential_attributes' 	=> \$discard_non_essential_attributes,
+			'add_missing_features' 				=> \$add_missing_features,
+			'help=i'								=> \$help );
+		
+		
+
+if( not defined($in_gff) ){
+	pod2usage(
+		-message => "Error: Parameter --input is required!\n\n",
+		-verbose => 1,
+		-exitval => 1,
+		-output  => \*STDERR
+	);   
+} 
+
+if( not defined($out_gff) ){
+	pod2usage(
+		-message => "Error: Parameter --output is required!\n\n",
+		-verbose => 1,
+		-exitval => 1,
+		-output  => \*STDERR
+	);   
+} 
+
+
+if( defined($change_id_single_exon_id) && defined($change_id_multi_exon_id) ){
+	pod2usage(
+		-message => "Error: Either use --change_id_single_exon_id or --change_id_multi_exon_id !\n\n",
+		-verbose => 1,
+		-exitval => 1,
+		-output  => \*STDERR
+	);   
+} 
+
+
+if( defined($help) ){
+   pod2usage(-verbose => 1 ,-exitval => 2);
+} 
+
+
+my $force_id_change = 0;
+if( defined($change_id_single_exon_id) || defined($change_id_multi_exon_id) ){
+	$force_id_change = 1;
+}
+
+my $gffFile = GFFFile::new($in_gff);
+$gffFile->read($discard_non_essential_attributes,$add_missing_features);
+my $gffGenes = $gffFile->get_genes_hash();
+
+# Ordering genes based on template name and start coord
+my @gffGenesArray = values %{$gffGenes};
+GFFUtils::sort_gene_arrays( \@gffGenesArray, 0 );
+
+open OUT, ">$out_gff" or croak "ERROR: Unable to open file $out_gff to write\n";
+
+print OUT $gffFile->get_header_comments();
+
+for my $currGene (@gffGenesArray) {
+		my $gene_id        = $currGene->get_id();
+		$currGene->set_name( $gene_id )  if ($force_id_change);
+		my $gffTranscripts = $currGene->get_transcripts_hash();
+		for my $currTranscript ( values %{$gffTranscripts} ) {
+
+			$currTranscript->force_multi_cds();
+			$currTranscript->correct_cds_phase();
+
+
+			$currTranscript->set_id( $gene_id . "-T" ) if ($force_id_change);
+			
+			# Set feature type to mRNA if it was originally as "transcript"
+			$currTranscript->set_transcript_type( "mRNA")  
+			  if $currTranscript->get_transcript_type() eq "transcript";
+
+			my $count = 1;
+			for my $currExon ( @{ $currTranscript->get_exon_array() } ) {
+				$currExon->set_id( $gene_id . "-E" . $count ) 
+					if ( defined($change_id_multi_exon_id) );
+					
+				$currExon->set_id( $gene_id . "-E"  ) 
+					if ( defined($change_id_single_exon_id) );
+				$count++;
+			}
+
+			$count = 1;
+			for my $currCDS ( @{ $currTranscript->get_CDS_array() } ) {
+				$currCDS->set_id( $gene_id . "-P" ) if ($force_id_change);
+				$count++;
+			}
+
+			$count = 1;
+			for my $currUTR ( @{ $currTranscript->get_UTR_array() } ) {
+				$currUTR->set_id( $gene_id . "-UTR" . $count ) if ($force_id_change);
+				$count++;
+			}
+			
+			$currTranscript->force_multi_cds();
+			$currTranscript->correct_cds_phase();
+		}
+	
+	print OUT $currGene->toGFF();	
+}
+close(OUT);
+

--- a/scripts/GFFLib/gff_set_src_col.pl
+++ b/scripts/GFFLib/gff_set_src_col.pl
@@ -1,0 +1,43 @@
+#!/bin/env perl
+
+# Set the 2nd column (src) of a GFF file to a value define by the user
+use strict;
+
+use FindBin;
+use lib "$FindBin::Bin";
+
+use GFFFile;
+
+
+my $usage =
+"gff_sort.pl. <src.  value> <GFF file> <output: modified GFF file>\n\n";
+
+die $usage if scalar(@ARGV) != 3;
+
+my $src_value		= $ARGV[0];
+my $in_gff		= $ARGV[1];
+my $out_gff		= $ARGV[2];
+
+
+my $gffFile = GFFFile::new($in_gff);
+$gffFile->read();
+
+my $gffGenes = $gffFile->get_genes_hash();
+
+# Ordering genes based on template name and start coord
+my @gffGenesArray = values %{$gffGenes};
+
+
+open OUT, ">$out_gff" or die "Unable to write on file $out_gff\n";
+for my $currGene (@gffGenesArray) {
+	my $content = $currGene->toGFF();
+        my @lines = split "\n", $content;
+
+	foreach my $curr_line ( @lines ){
+		my @cols  = split "\t", $curr_line;
+ 		$cols[1] = $src_value;
+		my $new_line = join "\t", @cols;
+		print OUT $new_line . "\n";
+	}
+}
+close(OUT);

--- a/scripts/GFFLib/gff_sort.pl
+++ b/scripts/GFFLib/gff_sort.pl
@@ -1,0 +1,49 @@
+#!/bin/env perl
+
+# Sort GFF file based on the numerical part of contig/scaffolds names
+# and then by the start coord. of genes
+
+use strict;
+
+use FindBin;
+use lib "$FindBin::Bin";
+
+use GFFFile;
+
+
+my $usage =
+"gff_sort.pl <GFF file> <output: sorted GFF file>\n\n";
+
+die $usage if scalar(@ARGV) != 2;
+
+my $in_gff        = $ARGV[0];
+my $out_gff       = $ARGV[1];
+
+my $gffFile = GFFFile::new($in_gff);
+$gffFile->read();
+
+my $gffGenes = $gffFile->get_genes_hash();
+
+# Ordering genes based on template name and start coord
+my @gffGenesArray = values %{$gffGenes};
+
+# Sort by the numerical part of chrom and then start coord of gene
+@gffGenesArray =
+  sort { 
+  		my ($a_num_chrom) = ( $a->get_chrom() =~ /(\d+)/ );
+  		my ($b_num_chrom) = ( $b->get_chrom() =~ /(\d+)/ );
+  		
+  		 return $a_num_chrom <=> $b_num_chrom || $a->get_start() <=> $b->get_start() }
+  @gffGenesArray;
+
+
+open OUT, ">$out_gff" or die "Unable to write on file $out_gff\n";
+for my $currGene (@gffGenesArray) {	
+	print OUT $currGene->toGFF();	
+}
+close(OUT);
+
+
+
+
+

--- a/scripts/GFFLib/gff_transcriptid_based_filtering.pl
+++ b/scripts/GFFLib/gff_transcriptid_based_filtering.pl
@@ -1,0 +1,72 @@
+#!/bin/env perl
+use strict;
+
+use FindBin;
+use lib "$FindBin::Bin";
+
+use GFFFile;
+
+my $usage = "$0 <id list file> <GFF file> <new GFF> [remove]\n\n";
+
+die $usage if ( scalar(@ARGV) != 3 && scalar(@ARGV) != 4 );
+
+my $idFile = $ARGV[0];
+my $inFile = $ARGV[1];
+my $outFile = $ARGV[2];
+my $shouldIremove = $ARGV[3];
+
+
+# Indicate if the transcript list should be either kept or removed from the GFF file
+my $remove = 0;
+$remove = 1 if ( defined( $shouldIremove ) );
+
+# Transcripts list
+my %transcript_list;
+
+my $num_transcripts_list = 0;
+my %found;
+
+# Read file listing transcripts
+open IN, $idFile or die "Unable to open file $idFile\n";
+while (<IN>) {
+	my $line = $_;
+	chomp $line;
+	$transcript_list{$line} = 1;
+	$num_transcripts_list++;
+	$found{$line} = -1;
+}
+
+# Reading GFF file
+my $gffFile = GFFFile::new( $inFile );
+$gffFile->read();
+
+my $gffGenes = $gffFile->get_genes_hash();
+
+my $num_transcripts_found = 0;
+
+
+open OUT, ">$outFile" or die "Unable to write on file $outFile\n";
+for my $currGene ( values %{$gffGenes} ) {
+	for my $currTranscript ( values %{ $currGene->get_transcripts_hash() } ) {
+
+		my $transcript_id = $currTranscript->get_id();
+
+		if ( $transcript_list{$transcript_id} == 1 ) {
+			$found{$transcript_id} = 1;
+			$num_transcripts_found++;
+
+			$currGene->delete_transcript($transcript_id);
+						
+		}
+	}
+	print OUT $currGene->toGFF();	
+}
+
+foreach my $curr_found ( keys %found ) {
+	print STDERR "NOT FOUND: $curr_found\n" if ( $found{$curr_found} == -1 );
+}
+
+print STDERR "Number of transcripts in the list: $num_transcripts_list\n";
+print STDERR "Number of transcripts found: $num_transcripts_found\n";
+
+close(OUT);

--- a/scripts/GFFLib/test_GFF_lib.pl
+++ b/scripts/GFFLib/test_GFF_lib.pl
@@ -1,0 +1,24 @@
+#!/usr/bin/perl
+use strict;
+
+use FindBin;
+use lib $FindBin::Bin;
+
+use GFFFile;
+use GFFUtils;
+
+my $usage = "test_GFF_lib.pl <GFF A>\n\n";
+
+die $usage if scalar(@ARGV) != 1;
+
+my $gff_filename_a = $ARGV[0];
+
+my $gff_a = GFFFile::new($gff_filename_a);
+$gff_a->read();
+
+#################
+# Print chromosomes in the GFF
+
+foreach my $curr_chrom ( $gff_a->get_chrom_names() ){
+	print $curr_chrom . "\n";	
+}

--- a/scripts/run_seeker.py
+++ b/scripts/run_seeker.py
@@ -1,0 +1,25 @@
+from seeker import SeekerFasta
+import argparse
+
+
+def run_seeker(input, output, opt_fasta, lstm_type):
+    seeker_fasta = SeekerFasta(f"{input}", LSTM_type=lstm_type)
+    seeker_fasta.save2bed(f"{output}")
+    if opt_fasta:
+        seeker_fasta.save2fasta(f"{output}.fasta")
+    print(f"[Seeker] Done {input}")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Better way to run Seeker")
+    parser.add_argument('-i', '--input', required=True,
+                        help="FASTA file to process")
+    parser.add_argument('-o', '--output', required=True,
+                        help="Directory with output filename (BED file with extension)")
+    parser.add_argument('-f', '--fasta', required=False, action='store_false', default=False,
+                        help="If provided, FASTA file with found viral sequences will be created")
+    parser.add_argument('--lstm', required=False, action='store_const', const="prophage", default="prophage",
+                        help="Type of LSTM to be used. 'propage' type is default.")
+    args = parser.parse_args()
+
+    run_seeker(args.input, args.output, args.fasta, args.lstm)

--- a/scripts/sanitize_genbank.py
+++ b/scripts/sanitize_genbank.py
@@ -1,0 +1,17 @@
+from Bio import SeqIO
+import argparse
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=" ")
+    parser.add_argument('-in', '--input', help='genbank file', required=True)
+    parser.add_argument('-out', '--output', help='genbank file with simplified IDs')
+    args = parser.parse_args()
+
+    seqs = SeqIO.parse(args.input, "genbank")
+    sanitized_seqs = []
+    for seq in seqs:
+        if '.' in seq.id:
+            seq.id = seq.name = seq.id.replace('.', '_dot_')
+        sanitized_seqs.append(seq)
+    SeqIO.write(sanitized_seqs, args.output, "genbank")

--- a/snakefiles/prophet.smk
+++ b/snakefiles/prophet.smk
@@ -1,0 +1,88 @@
+""""
+ProphET
+Manuscript: https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0223364
+Software: https://github.com/jaumlrc/ProphET
+"""
+
+import os
+import sys
+
+#CONFIG
+outDirName = 'prophet' #tool dir in global output directory
+prophetBuild = os.path.join(workflow.basedir, "../build/")
+prophetHome = os.path.join(prophetBuild, 'ProphET')
+prophetRun = os.path.join(prophetHome, 'ProphET_standalone.pl')
+prophetGit = 'https://github.com/jaumlrc/ProphET.git'
+
+# GENERIC CONFIG/RECIPES
+include: os.path.join(workflow.basedir, "../rules/prophET_rules.smk")
+
+#TARGET
+rule all:
+    input:
+        expand(os.path.join(outputdir, "{genome}_prophet_tptn.tsv"), genome=GENOMES)
+
+#BUILD
+rule build_prophet:
+    output:
+        prophetRun
+    conda:
+        "../conda_environments/prophet.yaml"
+    shell:
+        """
+        cd {prophetBuild}
+        git clone {prophetGit}
+        cd {prophetHome}
+        ./INSTALL.pl
+        """
+
+#RECIPES
+rule run_prophet:
+    input:
+        fa = os.path.join(outputdir, "{genome}.prophET.fna"),
+        gff = os.path.join(outputdir, "{genome}.prophET.gff"),
+        req = prophetRun
+    output:
+        os.path.join(outputdir, '{genome}', 'phages_coords')
+    conda:
+        "../conda_environments/prophet.yaml"
+    params:
+        dir = directory(os.path.join(outputdir, '{genome}'))
+    benchmark:
+        os.path.join(outputdir,"benchmarks","{genome}_prophet.txt")
+    resources:
+        mem_mb = 8000
+    shell:
+        """
+        perl {prophetRun} --fasta_in {input.fa} --gff_in {input.gff} --outdir {params.dir}
+        """
+
+rule prophet_2_tbl:
+    input:
+        os.path.join(outputdir, '{genome}/phages_coords')
+    output:
+        os.path.join(outputdir, "{genome}", "locs.tsv")
+    run:
+        infh = open(input[0],'r')
+        outfh = open(output[0], 'w')
+        for line in infh:
+            if not line.startswith("#"):
+                data = line.split("\t")
+                outfh.write(f"{data[0].strip().replace('_dot_', '.')}\t{data[2].strip()}\t{data[3].strip()}\n") # reinsert the dots that were remove to appease ptrophET
+        outfh.close()
+
+rule count_tp_tn:
+    input:
+        gen = os.path.join(test_genomes, "{genome}.gb.gz"),
+        tbl = os.path.join(outputdir, "{genome}", "locs.tsv")
+    output:
+        tp = os.path.join(outputdir, "{genome}_prophet_tptn.tsv")
+    params:
+        os.path.join(workflow.basedir,'../')
+    conda:
+        "../conda_environments/roblib.yaml"
+    shell:
+        """
+        export PYTHONPATH={params};
+        python3 {scripts}/compare_predictions_to_phages.py -t {input.gen} -r {input.tbl} > {output.tp}
+        """

--- a/snakefiles/seeker.smk
+++ b/snakefiles/seeker.smk
@@ -1,0 +1,81 @@
+""""
+Seeker
+Manuscript: https://academic.oup.com/nar/article/48/21/e121/5921300
+Software: https://github.com/gussow/seeker
+"""
+
+import os
+import sys
+
+#CONFIG
+outDirName = "seeker" #tool dir in global output directory
+seekerBuild = os.path.join(workflow.basedir, "../build/seeker")
+
+#GENERIC
+include: os.path.join(workflow.basedir, "../rules/preflight.smk")
+
+#TARGET
+rule all:
+    input:
+        expand(os.path.join(outputdir, "{genome}_seeker_tptn.tsv"), genome=GENOMES)
+
+#BUILD
+rule build_seeker:
+    output:
+        os.path.join(seekerBuild, 'setup.done')
+    conda:
+        "../conda_environments/seeker.yaml"
+    shell:
+        """
+        predict-metagenome
+        """
+
+#RECIPES
+rule run_seeker:
+    input:
+        fa = os.path.join(outputdir, "{genome}.fna"),
+    output:
+        bed = os.path.join(outputdir, "{genome}.bed")
+    benchmark:
+        os.path.join(outputdir, "benchmarks", "{genome}_seeker.txt")
+    conda:
+        "../conda_environments/seeker.yaml"
+    params:
+        os.path.join(workflow.basedir,'../'),
+    resources:
+        mem_mb = 8000
+    shell:
+        """
+        export PYTHONPATH={params}
+        python {scripts}/run_seeker.py -i {input.fa} -o {output.bed}
+        """
+
+rule seeker_2_tbl:
+    input:
+        os.path.join(outputdir, "{genome}.bed")
+    output:
+        os.path.join(outputdir, "{genome}", "_seeker_locs.tsv")
+    run:
+        infh = open(input[0],'r')
+        outfh = open(output[0], 'w')
+        for line in infh:
+            if not line.startswith("#"):
+                data = line.split("\t")
+                outfh.write(f"{data[0].strip()}\t{data[1].strip()}\t{data[2].strip()}\n")
+        outfh.close()
+
+rule count_tp_tn:
+    input:
+        gen = os.path.join(test_genomes, "{genome}.gb.gz"),
+        tbl = os.path.join(outputdir, "{genome}", "_seeker_locs.tsv")
+    output:
+        tp = os.path.join(outputdir, "{genome}_seeker_tptn.tsv")
+    params:
+        os.path.join(workflow.basedir,'../')
+    conda:
+        "../conda_environments/roblib.yaml"
+    shell:
+        """
+        export PYTHONPATH={params};
+        python3 {scripts}/compare_predictions_to_phages.py -t {input.gen} -r {input.tbl} > {output.tp}
+        """


### PR DESCRIPTION
 Summary of our work with Seeker and ProphET which we want to propose in this pull request:

## Seeker
### Things we've done:

- Default Seeker interface doesn't support the selection of the pre-trained model type (we suspect it’s ‘metagenome’ model by default but we need a prophage model) and specific output file.
- To overcome this limitation, we wrote a new command-line interface based on argparse. It runs Seeker as a Python package to wrap all these things up into one command. This is the `run_seeker.py` script located in the `scripts` folder. Script uses a model for prophages by default (`--lstm prophage`).   
+ We added a YAML file that can be used to set up conda environment for the Seeker
+ We prepared a straightforward snakemake file, based on phageboost.smk 

### Issues:
- No issues were detected

## ProphET

### Things we've done:

+ We simplified the ProphET installation using conda. This means that all dependencies (these from perl too) can be automatically installed, with no superuser privileges. Environment for the tool is specified in `prophet.yaml` located in `conda_environments` folder.
- ProphET requires a lot of input pre-processing
+ We have written a set of rules, specific to ProphET in `prophET_rules.smk`:

  - Sequence names should be purified from non-alpha-numeric characters except underscore (specifically dots)
  + We decided to correct this on the genbank level using the `sanitize_genbank.py` script (located in the `scripts` folder). The script creates temporary .gbk files with changed accession numbers. Any dots in accessions are replaced with the `_dot_` string. The rule for this action is specified in `sanitize_accesions`. To remain consistent with the names from the original .gbk files, we revert these changes just before creating a .tsv file in the `prophet_2_tbl` rule. 
  + The tool requires a specifically structured GFF file 
  - It was surprisingly difficult to convert genbank files to .gff files compatible with the tool. We have found that `bp_genbank2gff3.pl` from bioperl produces the most correct .gff files. Unfortunately, the script doesn't recognize compressed genbank files and require additional post-processing (`unpack_gbk` rule). The file generated by the script must be standardised to ProphET needs. This is done using a script provided by ProphET's authors - `gff_rewrite.pl` (`get_prophet_gff` rule). To remain consistent with the file system convention and enable the file conversion before installation, we moved the whole folder with the gff tools library - `ProphET/UTILS/GFFLib` to the `scripts` folder.

### Issues:
 - Analysis of files that have been previously analyzed to the same output folder might cause a crash (it happened only once and we don't know why).
 - Perl package Bio/Graphics can't be installed using conda, so ProphET doesn't generate images with potential prophage sites locations in the genome. It also prints a warning during analysis. It doesn't affect predictions in any other way, so it can be safely ignored.
